### PR TITLE
Support attributes in the interface.

### DIFF
--- a/include/client.h
+++ b/include/client.h
@@ -16,6 +16,7 @@
 #ifndef MIXERCLIENT_CLIENT_H
 #define MIXERCLIENT_CLIENT_H
 
+#include <chrono>
 #include <functional>
 #include <memory>
 #include <string>
@@ -58,10 +59,35 @@ struct MixerClientOptions {
   TransportInterface* transport;
 };
 
+struct Attributes {
+  // A structure to hold differnt types of value.
+  struct Value {
+    // Data type
+    enum ValueType { STRING, INT64, DOUBLE, BOOL, TIME, BYTES } type;
+
+    // Data value
+    union {
+      std::string str_v;  // for both STRING and BYTES
+      int64_t int64_v;
+      double double_v;
+      bool bool_v;
+      std::chrono::time_point<std::chrono::system_clock> time_v;
+    } value;
+  };
+
+  std::map<std::string, Value> attributes;
+};
+
 class MixerClient {
  public:
   // Destructor
   virtual ~MixerClient() {}
+
+  // Attribute based calls will be used.
+  // The protobuf message based calls will be removed.
+  virtual void Check(const Attributes& attributes, DoneFunc on_done) = 0;
+  virtual void Report(const Attributes& attributes, DoneFunc on_done) = 0;
+  virtual void Quota(const Attributes& attributes, DoneFunc on_done) = 0;
 
   // The async call.
   // on_check_done is called with the check status after cached

--- a/include/client.h
+++ b/include/client.h
@@ -60,7 +60,7 @@ struct MixerClientOptions {
 };
 
 struct Attributes {
-  // A structure to hold differnt types of value.
+  // A structure to hold different types of value.
   struct Value {
     // Data type
     enum ValueType { STRING, INT64, DOUBLE, BOOL, TIME, BYTES } type;
@@ -85,6 +85,12 @@ class MixerClient {
 
   // Attribute based calls will be used.
   // The protobuf message based calls will be removed.
+  // Callers should pass in the full set of attributes for the call.
+  // The client will use the full set attributes to check cache. If cache
+  // miss, an attribute context based on the underline gRPC stream will
+  // be used to generate attribute_update and send that to Mixer server.
+  // Callers don't need response data, they only need success or failure.
+  // The response data from mixer will be consumed by mixer client.
   virtual void Check(const Attributes& attributes, DoneFunc on_done) = 0;
   virtual void Report(const Attributes& attributes, DoneFunc on_done) = 0;
   virtual void Quota(const Attributes& attributes, DoneFunc on_done) = 0;

--- a/src/client_impl.cc
+++ b/src/client_impl.cc
@@ -36,6 +36,18 @@ MixerClientImpl::MixerClientImpl(const MixerClientOptions &options)
 
 MixerClientImpl::~MixerClientImpl() {}
 
+void MixerClientImpl::Check(const Attributes &attributes, DoneFunc on_done) {
+  on_done(Status(Code::UNIMPLEMENTED, "Method not implemented."));
+}
+
+void MixerClientImpl::Report(const Attributes &attributes, DoneFunc on_done) {
+  on_done(Status(Code::UNIMPLEMENTED, "Method not implemented."));
+}
+
+void MixerClientImpl::Quota(const Attributes &attributes, DoneFunc on_done) {
+  on_done(Status(Code::UNIMPLEMENTED, "Method not implemented."));
+}
+
 void MixerClientImpl::Check(const CheckRequest &request,
                             CheckResponse *response, DoneFunc on_done) {
   check_transport_.Call(request, response, on_done);

--- a/src/client_impl.h
+++ b/src/client_impl.h
@@ -30,6 +30,10 @@ class MixerClientImpl : public MixerClient {
   // Destructor
   virtual ~MixerClientImpl();
 
+  virtual void Check(const Attributes& attributes, DoneFunc on_done);
+  virtual void Report(const Attributes& attributes, DoneFunc on_done);
+  virtual void Quota(const Attributes& attributes, DoneFunc on_done);
+
   // The async call.
   // on_check_done is called with the check status after cached
   // check_response is returned in case of cache hit, otherwise called after


### PR DESCRIPTION
The full set of attributes will be used between proxy and mixer_client.  Mixer_client will use attribute context (within a gRPC stream) to generate attribute_update before calling Mixer.

The current calls using protobuf messages will be removed.