### PR TITLE
Fix crash when mixer server is killed.

### DIFF
--- a/include/transport.h
+++ b/include/transport.h
@@ -53,11 +53,11 @@ class ReadInterface {
   virtual void OnClose(const ::google::protobuf::util::Status &) = 0;
 };
 
-typedef std::unique_ptr<WriteInterface<::istio::mixer::v1::CheckRequest>>
+typedef std::shared_ptr<WriteInterface<::istio::mixer::v1::CheckRequest>>
     CheckWriterPtr;
-typedef std::unique_ptr<WriteInterface<::istio::mixer::v1::ReportRequest>>
+typedef std::shared_ptr<WriteInterface<::istio::mixer::v1::ReportRequest>>
     ReportWriterPtr;
-typedef std::unique_ptr<WriteInterface<::istio::mixer::v1::QuotaRequest>>
+typedef std::shared_ptr<WriteInterface<::istio::mixer::v1::QuotaRequest>>
     QuotaWriterPtr;
 
 typedef ReadInterface<::istio::mixer::v1::CheckResponse> *CheckReaderRawPtr;

--- a/src/stream_transport.h
+++ b/src/stream_transport.h
@@ -145,9 +145,7 @@ class StreamTransport {
     std::shared_ptr<ReaderImpl<ResponseType>> reader = reader_.lock();
     if (!writer || !reader || writer->is_write_closed()) {
       reader = std::make_shared<ReaderImpl<ResponseType>>();
-      auto writer_unique_ptr = transport_->NewStream(reader.get());
-      // Transfer writer ownership to shared_ptr.
-      writer.reset(writer_unique_ptr.release());
+      writer = transport_->NewStream(reader.get());
       reader_ = reader;
       writer_ = writer;
       // Reader and Writer objects are owned by the OnClose callback.


### PR DESCRIPTION
Use shared_ptr for Writer interface so it can pass a ref_count to ReaderThread.