### PR TITLE
Sync up the stream.Call

### DIFF
--- a/src/transport.h
+++ b/src/transport.h
@@ -34,13 +34,14 @@ class Transport : public AttributeConverter<RequestType> {
   // Send the attributes
   void Send(const Attributes& attributes, ResponseType* response,
             DoneFunc on_done) {
+    std::lock_guard<std::mutex> lock(mutex_);
     stream_.Call(attributes, response, on_done);
   }
 
   // Convert to a protobuf
+  // This is called by stream_.Call so it is within the mutex lock.
   void FillProto(StreamID stream_id, const Attributes& attributes,
                  RequestType* request) {
-    std::lock_guard<std::mutex> lock(mutex_);
     if (stream_id != last_stream_id_) {
       attribute_context_.reset(new AttributeContext);
       last_stream_id_ = stream_id;
@@ -53,7 +54,7 @@ class Transport : public AttributeConverter<RequestType> {
  private:
   // A stream transport
   StreamTransport<RequestType, ResponseType> stream_;
-  // Mutex guarding the access of attribute_context and last_stream_id;
+  // Mutex to sync-up stream_.Call, only one at time.
   std::mutex mutex_;
   // The attribute context for sending attributes
   std::unique_ptr<AttributeContext> attribute_context_;

--- a/src/transport.h
+++ b/src/transport.h
@@ -38,6 +38,7 @@ class Transport : public AttributeConverter<RequestType> {
     stream_.Call(attributes, response, on_done);
   }
 
+ private:
   // Convert to a protobuf
   // This is called by stream_.Call so it is within the mutex lock.
   void FillProto(StreamID stream_id, const Attributes& attributes,
@@ -51,7 +52,6 @@ class Transport : public AttributeConverter<RequestType> {
     request->set_request_index(attribute_context_->IncRequestIndex());
   }
 
- private:
   // A stream transport
   StreamTransport<RequestType, ResponseType> stream_;
   // Mutex to sync-up stream_.Call, only one at time.


### PR DESCRIPTION
stream.Call has two steps:  FillProto with attribute context, and gRPC.Write.  
FillingProto and gRPC.Write() are individually protected. But two steps should be done atomically.  Otherwise, following may happen:  FillProto 1 with ctx,  write did not happen, then FillProto 2 whose context is based on 1,  then 2 Write to grpc first. then write 1.

This change will make sure stream.Call is sync.  its two steps are done atomically
