### PR TITLE
Support FillProto for QuotaRequest.

### DIFF
--- a/include/attribute.h
+++ b/include/attribute.h
@@ -77,6 +77,11 @@ struct Attributes {
   std::map<std::string, Value> attributes;
 };
 
+// The attribute key to fill "quota" field in the QuotaRequest.
+extern const std::string kQuotaName;
+// The attribute key to fill "amount" field in the QuotaRequest.
+extern const std::string kQuotaAmount;
+
 }  // namespace mixer_client
 }  // namespace istio
 

--- a/src/attribute.cc
+++ b/src/attribute.cc
@@ -19,6 +19,9 @@
 namespace istio {
 namespace mixer_client {
 
+const std::string kQuotaName = "quota.name";
+const std::string kQuotaAmount = "quota.amount";
+
 Attributes::Value Attributes::StringValue(const std::string& str) {
   Attributes::Value v;
   v.type = Attributes::Value::STRING;


### PR DESCRIPTION
Use two special attributes "quota.name" and "quota.amount" to pass info to protobuf QuotaRequest.