### PR TITLE
Support cache key for partial string map value

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -23,6 +23,8 @@ cc_library(
         "src/attribute_context.cc",
         "src/attribute_context.h",
         "src/attribute_converter.h",
+        "src/cache_key_set.cc",
+        "src/cache_key_set.h",
         "src/check_cache.cc",
         "src/check_cache.h",
         "src/client_impl.cc",
@@ -116,6 +118,17 @@ cc_test(
     name = "md5_test",
     size = "small",
     srcs = ["utils/md5_test.cc"],
+    linkstatic = 1,
+    deps = [
+        ":mixer_client_lib",
+        "//external:googletest_main",
+    ],
+)
+
+cc_test(
+    name = "cache_key_set_test",
+    size = "small",
+    srcs = ["src/cache_key_set_test.cc"],
     linkstatic = 1,
     deps = [
         ":mixer_client_lib",

--- a/include/options.h
+++ b/include/options.h
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <set>
+#include <vector>
 
 namespace istio {
 namespace mixer_client {
@@ -59,7 +60,7 @@ struct CheckOptions {
 
   // Only the attributes in this set are used to caclculate cache key.
   // If empty, check cache is disabled.
-  std::set<std::string> cache_keys;
+  std::vector<std::string> cache_keys;
 };
 
 // Options controlling report behavior.

--- a/src/cache_key_set.cc
+++ b/src/cache_key_set.cc
@@ -1,0 +1,49 @@
+/* Copyright 2017 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/cache_key_set.h"
+
+namespace istio {
+namespace mixer_client {
+
+CacheKeySet::CacheKeySet(const std::vector<std::string>& cache_keys) {
+  for (const std::string& key : cache_keys) {
+    size_t pos = key.find_first_of('/');
+    if (pos == std::string::npos) {
+      // Always override with an empty one.
+      // It handles case where
+      // "key/sub_key" comes first, then "key" come.
+      // In this case, "key" wins.
+      key_map_[key] = SubKeySet();
+    } else {
+      std::string split_key = key.substr(0, pos);
+      std::string split_sub_key = key.substr(pos + 1);
+      auto it = key_map_.find(split_key);
+      if (it == key_map_.end()) {
+        key_map_[split_key] = SubKeySet();
+        key_map_[split_key].sub_keys_.insert(split_sub_key);
+      } else {
+        // If map to empty set, it was created by "key"
+        // without sub_key, keep it as empty set.
+        if (!it->second.sub_keys_.empty()) {
+          it->second.sub_keys_.insert(split_sub_key);
+        }
+      }
+    }
+  }
+}
+
+}  // namespace mixer_client
+}  // namespace istio

--- a/src/cache_key_set.h
+++ b/src/cache_key_set.h
@@ -43,7 +43,7 @@ class SubKeySet {
 
 // A class to handle cache key set
 // A std::set will not work for string map sub keys.
-// For AtringMap attruibute,
+// For a StringMap attruibute,
 // If cache key is "attribute.key", all values will be used.
 // If cache key is "attribute.key/map.key", only the map key is used.
 // If both format exists, the whole map will be used.

--- a/src/cache_key_set.h
+++ b/src/cache_key_set.h
@@ -1,0 +1,69 @@
+/* Copyright 2017 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MIXER_CLIENT_CACHE_KEY_SET_H_
+#define MIXER_CLIENT_CACHE_KEY_SET_H_
+
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace istio {
+namespace mixer_client {
+
+// A class to store sub key set
+class SubKeySet {
+ public:
+  // Check if the sub key is in the set.
+  bool Found(const std::string& sub_key) const {
+    if (sub_keys_.empty()) {
+      return true;
+    } else {
+      return sub_keys_.find(sub_key) != sub_keys_.end();
+    }
+  }
+
+ private:
+  friend class CacheKeySet;
+  std::set<std::string> sub_keys_;
+};
+
+// A class to handle cache key set
+// A std::set will not work for string map sub keys.
+// For AtringMap attruibute,
+// If cache key is "attribute.key", all values will be used.
+// If cache key is "attribute.key/map.key", only the map key is used.
+// If both format exists, the whole map will be used.
+class CacheKeySet {
+ public:
+  CacheKeySet(const std::vector<std::string>& cache_keys);
+
+  // Return nullptr if the key is not in the set.
+  const SubKeySet* Find(const std::string& key) const {
+    const auto it = key_map_.find(key);
+    return it == key_map_.end() ? nullptr : &it->second;
+  }
+
+  bool empty() const { return key_map_.empty(); }
+
+ private:
+  std::map<std::string, SubKeySet> key_map_;
+};
+
+}  // namespace mixer_client
+}  // namespace istio
+
+#endif  // MIXER_CLIENT_CACHE_KEY_SET_H_

--- a/src/cache_key_set_test.cc
+++ b/src/cache_key_set_test.cc
@@ -1,0 +1,53 @@
+/* Copyright 2017 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/cache_key_set.h"
+#include "gtest/gtest.h"
+
+namespace istio {
+namespace mixer_client {
+namespace {
+
+TEST(CacheKeySetTest, TestNonSubkey) {
+  CacheKeySet s({"key1", "key2"});
+  EXPECT_TRUE(s.Find("key1") != nullptr);
+  EXPECT_TRUE(s.Find("key2") != nullptr);
+  EXPECT_TRUE(s.Find("xyz") == nullptr);
+}
+
+TEST(CacheKeySetTest, TestSubkeyLater) {
+  // Whole key comes first, then sub key comes.
+  CacheKeySet s({"key1", "key2", "key2/sub"});
+  EXPECT_TRUE(s.Find("key2")->Found("sub"));
+  EXPECT_TRUE(s.Find("key2")->Found("xyz"));
+}
+
+TEST(CacheKeySetTest, TestSubkeyFirst) {
+  // The sub key comes first, then the whole key comes
+  CacheKeySet s({"key1", "key2/sub", "key2"});
+  EXPECT_TRUE(s.Find("key2")->Found("sub"));
+  EXPECT_TRUE(s.Find("key2")->Found("xyz"));
+}
+
+TEST(CacheKeySetTest, TestSubkey) {
+  CacheKeySet s({"key1", "key2/sub1", "key2/sub2"});
+  EXPECT_TRUE(s.Find("key2")->Found("sub1"));
+  EXPECT_TRUE(s.Find("key2")->Found("sub2"));
+  EXPECT_FALSE(s.Find("key2")->Found("xyz"));
+}
+
+}  // namespace
+}  // namespace mixer_client
+}  // namespace istio

--- a/src/check_cache.h
+++ b/src/check_cache.h
@@ -27,7 +27,7 @@
 #include "include/client.h"
 #include "include/options.h"
 #include "mixer/v1/service.pb.h"
-#include "src/signature.h"
+#include "src/cache_key_set.h"
 #include "utils/simple_lru_cache.h"
 #include "utils/simple_lru_cache_inl.h"
 
@@ -116,6 +116,9 @@ class CheckCache {
 
   // The check options.
   CheckOptions options_;
+
+  // The cache keys.
+  CacheKeySet cache_keys_;
 
   // Mutex guarding the access of cache_;
   std::mutex cache_mutex_;

--- a/src/signature.h
+++ b/src/signature.h
@@ -21,13 +21,14 @@
 
 #include <string>
 #include "include/client.h"
+#include "src/cache_key_set.h"
 
 namespace istio {
 namespace mixer_client {
 
 // Generates signature for Attributes.
 std::string GenerateSignature(const Attributes& attributes,
-                              const std::set<std::string>& cache_keys);
+                              const CacheKeySet& cache_keys);
 
 }  // namespace mixer_client
 }  // namespace istio

--- a/src/signature_test.cc
+++ b/src/signature_test.cc
@@ -64,12 +64,12 @@ class SignatureUtilTest : public ::testing::Test {
     attributes_.attributes[key] = Attributes::StringMapValue(std::move(value));
   }
 
-  std::set<std::string> GetKeys() const {
-    std::set<std::string> keys;
+  CacheKeySet GetKeys() const {
+    std::vector<std::string> keys;
     for (const auto& it : attributes_.attributes) {
-      keys.insert(it.first);
+      keys.push_back(it.first);
     }
-    return keys;
+    return CacheKeySet(keys);
   }
 
   Attributes attributes_;


### PR DESCRIPTION
If a cache key is "request.headers/:method".  It means only to use the string map attribute "request.headers" and its ":method" key.  
If a cache key is "source.labels",  it means to use all values in "source.labels" string map attribute.