### PR TITLE
Use check response status.

### DIFF
--- a/utils/protobuf.cc
+++ b/utils/protobuf.cc
@@ -48,5 +48,9 @@ milliseconds ToMilliseonds(const Duration& duration) {
          duration_cast<milliseconds>(nanoseconds(duration.nanos()));
 }
 
+Status ConvertRpcStatus(const ::google::rpc::Status& status) {
+  return Status(static_cast<Code>(status.code()), status.message());
+}
+
 }  // namespace mixer_client
 }  // namespace istio

--- a/utils/protobuf.h
+++ b/utils/protobuf.h
@@ -19,6 +19,7 @@
 #include "google/protobuf/duration.pb.h"
 #include "google/protobuf/stubs/status.h"
 #include "google/protobuf/timestamp.pb.h"
+#include "mixer/v1/service.pb.h"
 
 #include <chrono>
 
@@ -35,6 +36,10 @@ namespace mixer_client {
 // Convert from prtoobuf duration to chrono duration.
 std::chrono::milliseconds ToMilliseonds(
     const ::google::protobuf::Duration& duration);
+
+// Convert from grpc status to protobuf status.
+::google::protobuf::util::Status ConvertRpcStatus(
+    const ::google::rpc::Status& status);
 
 }  // namespace mixer_client
 }  // namespace istio


### PR DESCRIPTION
rpc.status used to be both network status and server status.  Now response body added status, it is for server status.   rpc.status is for network status. 

Client need to use response.status and convert it for the check request.
