### PR TITLE
update global dictionary to 124 again.

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -378,7 +378,7 @@ cc_proto_library(
 
     native.new_git_repository(
         name = "mixerapi_git",
-        commit = "ee9769f5b3304d9e01cd7ed6fb1dbb9b08e96210",
+        commit = "2ee198c96b92a3d8aac21bf8e1fae0c8fdaa138c",
         remote = "https://github.com/istio/api.git",
         build_file_content = BUILD,
     )

--- a/src/attribute_converter_test.cc
+++ b/src/attribute_converter_test.cc
@@ -200,7 +200,7 @@ default_words: "time-key"
 default_words: "int-key2"
 default_words: "key"
 default_words: "value"
-global_word_count: 111
+global_word_count: 124
 )";
 
 class AttributeConverterTest : public ::testing::Test {

--- a/src/global_dictionary.cc
+++ b/src/global_dictionary.cc
@@ -140,6 +140,19 @@ const std::vector<std::string> kGlobalWords{
     "text/html; charset=utf-8",
     "text/plain",
     "text/plain; charset=utf-8",
+    "0",
+    "1",
+    "True",
+    "False",
+    "gzip, deflate",
+    "max-age=0",
+    "x-envoy-upstream-service-time",
+    "x-envoy-internal",
+    "x-envoy-expected-rq-timeout-ms",
+    "x-ot-span-context",
+    "x-b3-traceid",
+    "x-b3-sampled",
+    "x-b3-spanid",
 };
 
 }  // namespace


### PR DESCRIPTION
There are more global dictionary changes coming. Need to check this in.

Mixer is still not easy to build by proxy. The work around is to create a fork from old version of working mixer and add the global dictionary to that forked mixer. This mixer is just for proxy integration, as long as its transport layer (attribute extraction code) is not changed, this approach should work. So far, it is not changed.

Mixer team is going to build a mixer test stub with gRPC api and attribute extraction with minimum dependency (#1023). Once this is in, Istio/Proxy can switch to use that.
