### PR TITLE
Use mixer python code to convert global dictionary.

### DIFF
--- a/create_global_dictionary.py
+++ b/create_global_dictionary.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 import sys
-import yaml
 
 TOP = r"""/* Copyright 2017 Istio Authors. All Rights Reserved.
  *
@@ -60,8 +59,10 @@ const std::vector<std::string>& GetGlobalWords() { return kGlobalWords; }
 }  // namespace istio"""
 
 all_words = ''
-for word in yaml.load(open(sys.argv[1])):
-    all_words += "    \"%s\",\n" % word
+with open(sys.argv[1]) as src_file:
+    for line in src_file:
+        if line.startswith("-"):
+            all_words += "    \"" + line[1:].strip() + "\",\n"
 
 print TOP + all_words + BOTTOM
 

--- a/src/global_dictionary.cc
+++ b/src/global_dictionary.cc
@@ -123,7 +123,7 @@ const std::vector<std::string> kGlobalWords{
     "POST",
     "http",
     "envoy",
-    "200",
+    "'200'",
     "Keep-Alive",
     "chunked",
     "x-envoy-service-time",


### PR DESCRIPTION
MIxer python global dictionary conversion code did not use "yaml" package.  Instead it is just checking "-" prefix.  

https://github.com/istio/mixer/blob/master/bin/generate_word_list.py

If python yaml is used, 200 has to be wrapped with single quote as '200' so it will be loaded as string instead of int.

Since mixer converter did not use yaml loading,  mixer dictionary is using '200' with single quota. 

To be consistent,   mixerclient should not use yaml loading too. Instead of changing mixer, it is easier to change client.