### PR TITLE
Quota cache key should include quota name.

### DIFF
--- a/src/check_cache.cc
+++ b/src/check_cache.cc
@@ -103,7 +103,7 @@ Status CheckCache::Check(const Attributes& attributes, Tick time_now) {
   for (const auto& it : referenced_map_) {
     const Referenced& reference = it.second;
     std::string signature;
-    if (!reference.Signature(attributes, &signature)) {
+    if (!reference.Signature(attributes, "", &signature)) {
       continue;
     }
 
@@ -139,7 +139,7 @@ Status CheckCache::CacheResponse(const Attributes& attributes,
     return ConvertRpcStatus(response.precondition().status());
   }
   std::string signature;
-  if (!referenced.Signature(attributes, &signature)) {
+  if (!referenced.Signature(attributes, "", &signature)) {
     GOOGLE_LOG(ERROR) << "Response referenced mismatchs with request";
     GOOGLE_LOG(ERROR) << "Request attributes: " << attributes.DebugString();
     GOOGLE_LOG(ERROR) << "Referenced attributes: " << referenced.DebugString();

--- a/src/quota_cache.cc
+++ b/src/quota_cache.cc
@@ -169,7 +169,7 @@ void QuotaCache::CheckCache(const Attributes& request, bool check_use_cache,
   for (const auto& it : quota_ref.referenced_map) {
     const Referenced& referenced = it.second;
     std::string signature;
-    if (!referenced.Signature(request, &signature)) {
+    if (!referenced.Signature(request, quota->name, &signature)) {
       continue;
     }
     QuotaLRUCache::ScopedLookup lookup(cache_.get(), signature);
@@ -211,7 +211,7 @@ void QuotaCache::SetResponse(const Attributes& attributes,
   }
 
   std::string signature;
-  if (!referenced.Signature(attributes, &signature)) {
+  if (!referenced.Signature(attributes, quota_name, &signature)) {
     GOOGLE_LOG(ERROR) << "Quota response referenced mismatchs with request";
     GOOGLE_LOG(ERROR) << "Request attributes: " << attributes.DebugString();
     GOOGLE_LOG(ERROR) << "Referenced attributes: " << referenced.DebugString();

--- a/src/referenced.cc
+++ b/src/referenced.cc
@@ -74,6 +74,7 @@ bool Referenced::Fill(const ReferencedAttributes& reference) {
 }
 
 bool Referenced::Signature(const Attributes& attributes,
+                           const std::string& extra_key,
                            std::string* signature) const {
   for (const std::string& key : absence_keys_) {
     // if an "absence" key exists, return false for mis-match.
@@ -129,6 +130,7 @@ bool Referenced::Signature(const Attributes& attributes,
     }
     hasher.Update(kDelimiter, kDelimiterLength);
   }
+  hasher.Update(extra_key);
 
   *signature = hasher.Digest();
   return true;

--- a/src/referenced.h
+++ b/src/referenced.h
@@ -38,9 +38,8 @@ class Referenced {
   // Return false if attributes are mismatched, such as "absence" attributes
   // present
   // or "exact" match attributes don't present.
-  bool Signature(const Attributes& attributes,
-		 const std::string& extra_key,
-		 std::string* signature) const;
+  bool Signature(const Attributes& attributes, const std::string& extra_key,
+                 std::string* signature) const;
 
   // A hash value to identify an instance.
   std::string Hash() const;

--- a/src/referenced.h
+++ b/src/referenced.h
@@ -38,7 +38,9 @@ class Referenced {
   // Return false if attributes are mismatched, such as "absence" attributes
   // present
   // or "exact" match attributes don't present.
-  bool Signature(const Attributes& attributes, std::string* signature) const;
+  bool Signature(const Attributes& attributes,
+		 const std::string& extra_key,
+		 std::string* signature) const;
 
   // A hash value to identify an instance.
   std::string Hash() const;

--- a/src/referenced_test.cc
+++ b/src/referenced_test.cc
@@ -137,12 +137,12 @@ TEST(ReferencedTest, NegativeSignature1Test) {
   Attributes attributes1;
   // "target.service" should be absence.
   attributes1.attributes["target.service"] = Attributes::StringValue("foo");
-  EXPECT_FALSE(referenced.Signature(attributes1, &signature));
+  EXPECT_FALSE(referenced.Signature(attributes1, "", &signature));
 
   Attributes attributes2;
   // many keys should exist.
   attributes2.attributes["bytes-key"] = Attributes::StringValue("foo");
-  EXPECT_FALSE(referenced.Signature(attributes2, &signature));
+  EXPECT_FALSE(referenced.Signature(attributes2, "", &signature));
 }
 
 TEST(ReferencedTest, OKSignature1Test) {
@@ -172,9 +172,9 @@ TEST(ReferencedTest, OKSignature1Test) {
       Attributes::StringMapValue(std::move(string_map));
 
   std::string signature;
-  EXPECT_TRUE(referenced.Signature(attributes, &signature));
+  EXPECT_TRUE(referenced.Signature(attributes, "extra", &signature));
 
-  EXPECT_EQ(MD5::DebugString(signature), "3941a660b4df440dd2ff65f78bf61f2a");
+  EXPECT_EQ(MD5::DebugString(signature), "cfcf5f20f58a44da8832456742bf7b88");
 }
 
 }  // namespace


### PR DESCRIPTION
Multiple quota metrics are sharing the same cache.  Cache key should include quota name otherwise they may collide.