### PR TITLE
Copy path matcher code over for api_spec.

### DIFF
--- a/api_spec/BUILD
+++ b/api_spec/BUILD
@@ -1,0 +1,59 @@
+# Copyright 2017 Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+licenses(["notice"])
+
+cc_library(
+    name = "api_spec_lib",
+    srcs = [
+        "src/http_template.cc",
+        "src/http_template.h",
+        "src/path_matcher.h",
+        "src/path_matcher_node.cc",
+        "src/path_matcher_node.h",
+    ],
+    hdrs = [
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_test(
+    name = "path_matcher_test",
+    size = "small",
+    srcs = ["src/path_matcher_test.cc"],
+    linkopts = [
+        "-lm",
+        "-lpthread",
+    ],
+    linkstatic = 1,
+    deps = [
+        ":api_spec_lib",
+        "//external:googletest_main",
+    ],
+)
+
+cc_test(
+    name = "http_template_test",
+    size = "small",
+    srcs = ["src/http_template_test.cc"],
+    linkopts = [
+        "-lm",
+        "-lpthread",
+    ],
+    linkstatic = 1,
+    deps = [
+        ":api_spec_lib",
+        "//external:googletest_main",
+    ],
+)

--- a/api_spec/src/http_template.cc
+++ b/api_spec/src/http_template.cc
@@ -365,14 +365,14 @@ const char HttpTemplate::kWildCardPathPartKey[] = "*";
 
 const char HttpTemplate::kWildCardPathKey[] = "**";
 
-HttpTemplate *HttpTemplate::Parse(const std::string &ht) {
+std::unique_ptr<HttpTemplate> HttpTemplate::Parse(const std::string &ht) {
   Parser p(ht);
   if (!p.Parse() || !p.ValidateParts()) {
     return nullptr;
   }
 
-  return new HttpTemplate(std::move(p.segments()), std::move(p.verb()),
-                          std::move(p.variables()));
+  return std::unique_ptr<HttpTemplate>(new HttpTemplate(
+      std::move(p.segments()), std::move(p.verb()), std::move(p.variables())));
 }
 
 }  // namespace api_spec

--- a/api_spec/src/http_template.cc
+++ b/api_spec/src/http_template.cc
@@ -1,0 +1,379 @@
+/* Copyright 2017 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cassert>
+#include <string>
+#include <vector>
+
+#include "http_template.h"
+
+namespace istio {
+namespace api_spec {
+
+namespace {
+
+// TODO: implement an error sink.
+
+// HTTP Template Grammar:
+// Questions:
+//   - what are the constraints on LITERAL and IDENT?
+//   - what is the character set for the grammar?
+//
+// Template = "/" Segments [ Verb ] ;
+// Segments = Segment { "/" Segment } ;
+// Segment  = "*" | "**" | LITERAL | Variable ;
+// Variable = "{" FieldPath [ "=" Segments ] "}" ;
+// FieldPath = IDENT { "." IDENT } ;
+// Verb     = ":" LITERAL ;
+class Parser {
+ public:
+  Parser(const std::string &input)
+      : input_(input), tb_(0), te_(0), in_variable_(false) {}
+
+  bool Parse() {
+    if (!ParseTemplate() || !ConsumedAllInput()) {
+      return false;
+    }
+    PostProcessVariables();
+    return true;
+  }
+
+  std::vector<std::string> &segments() { return segments_; }
+  std::string &verb() { return verb_; }
+  std::vector<HttpTemplate::Variable> &variables() { return variables_; }
+
+  // only constant path segments are allowed after '**'.
+  bool ValidateParts() {
+    bool found_wild_card = false;
+    for (size_t i = 0; i < segments_.size(); i++) {
+      if (!found_wild_card) {
+        if (segments_[i] == HttpTemplate::kWildCardPathKey) {
+          found_wild_card = true;
+        }
+      } else if (segments_[i] == HttpTemplate::kSingleParameterKey ||
+                 segments_[i] == HttpTemplate::kWildCardPathPartKey ||
+                 segments_[i] == HttpTemplate::kWildCardPathKey) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+ private:
+  // Template = "/" Segments [ Verb ] ;
+  bool ParseTemplate() {
+    if (!Consume('/')) {
+      // Expected '/'
+      return false;
+    }
+    if (!ParseSegments()) {
+      return false;
+    }
+
+    if (EnsureCurrent() && current_char() == ':') {
+      if (!ParseVerb()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // Segments = Segment { "/" Segment } ;
+  bool ParseSegments() {
+    if (!ParseSegment()) {
+      return false;
+    }
+
+    for (;;) {
+      if (!Consume('/')) break;
+      if (!ParseSegment()) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  // Segment  = "*" | "**" | LITERAL | Variable ;
+  bool ParseSegment() {
+    if (!EnsureCurrent()) {
+      return false;
+    }
+    switch (current_char()) {
+      case '*': {
+        Consume('*');
+        if (Consume('*')) {
+          // **
+          segments_.push_back("**");
+          if (in_variable_) {
+            return MarkVariableHasWildCardPath();
+          }
+          return true;
+        } else {
+          segments_.push_back("*");
+          return true;
+        }
+      }
+
+      case '{':
+        return ParseVariable();
+      default:
+        return ParseLiteralSegment();
+    }
+  }
+
+  // Variable = "{" FieldPath [ "=" Segments ] "}" ;
+  bool ParseVariable() {
+    if (!Consume('{')) {
+      return false;
+    }
+    if (!StartVariable()) {
+      return false;
+    }
+    if (!ParseFieldPath()) {
+      return false;
+    }
+    if (Consume('=')) {
+      if (!ParseSegments()) {
+        return false;
+      }
+    } else {
+      // {field_path} is equivalent to {field_path=*}
+      segments_.push_back("*");
+    }
+    if (!EndVariable()) {
+      return false;
+    }
+    if (!Consume('}')) {
+      return false;
+    }
+    return true;
+  }
+
+  bool ParseLiteralSegment() {
+    std::string ls;
+    if (!ParseLiteral(&ls)) {
+      return false;
+    }
+    segments_.push_back(ls);
+    return true;
+  }
+
+  // FieldPath = IDENT { "." IDENT } ;
+  bool ParseFieldPath() {
+    if (!ParseIdentifier()) {
+      return false;
+    }
+    while (Consume('.')) {
+      if (!ParseIdentifier()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // Verb     = ":" LITERAL ;
+  bool ParseVerb() {
+    if (!Consume(':')) return false;
+    if (!ParseLiteral(&verb_)) return false;
+    return true;
+  }
+
+  bool ParseIdentifier() {
+    std::string idf;
+
+    // Initialize to false to handle empty literal.
+    bool result = false;
+
+    while (NextChar()) {
+      char c;
+      switch (c = current_char()) {
+        case '.':
+        case '}':
+        case '=':
+          return result && AddFieldIdentifier(std::move(idf));
+        default:
+          Consume(c);
+          idf.push_back(c);
+          break;
+      }
+      result = true;
+    }
+    return result && AddFieldIdentifier(std::move(idf));
+  }
+
+  bool ParseLiteral(std::string *lit) {
+    if (!EnsureCurrent()) {
+      return false;
+    }
+
+    // Initialize to false in case we encounter an empty literal.
+    bool result = false;
+
+    for (;;) {
+      char c;
+      switch (c = current_char()) {
+        case '/':
+        case ':':
+        case '}':
+          return result;
+        default:
+          Consume(c);
+          lit->push_back(c);
+          break;
+      }
+
+      result = true;
+
+      if (!NextChar()) {
+        break;
+      }
+    }
+    return result;
+  }
+
+  bool Consume(char c) {
+    if (tb_ >= te_ && !NextChar()) {
+      return false;
+    }
+    if (current_char() != c) {
+      return false;
+    }
+    tb_++;
+    return true;
+  }
+
+  bool ConsumedAllInput() { return tb_ >= input_.size(); }
+
+  bool EnsureCurrent() { return tb_ < te_ || NextChar(); }
+
+  bool NextChar() {
+    if (te_ < input_.size()) {
+      te_++;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  // Returns the character looked at.
+  char current_char() const {
+    return tb_ < te_ && te_ <= input_.size() ? input_[te_ - 1] : -1;
+  }
+
+  HttpTemplate::Variable &CurrentVariable() { return variables_.back(); }
+
+  bool StartVariable() {
+    if (!in_variable_) {
+      variables_.push_back(HttpTemplate::Variable{});
+      CurrentVariable().start_segment = segments_.size();
+      CurrentVariable().has_wildcard_path = false;
+      in_variable_ = true;
+      return true;
+    } else {
+      // nested variables are not allowed
+      return false;
+    }
+  }
+
+  bool EndVariable() {
+    if (in_variable_ && !variables_.empty()) {
+      CurrentVariable().end_segment = segments_.size();
+      in_variable_ = false;
+      return ValidateVariable(CurrentVariable());
+    } else {
+      // something's wrong we're not in a variable
+      return false;
+    }
+  }
+
+  bool AddFieldIdentifier(std::string id) {
+    if (in_variable_ && !variables_.empty()) {
+      CurrentVariable().field_path.emplace_back(std::move(id));
+      return true;
+    } else {
+      // something's wrong we're not in a variable
+      return false;
+    }
+  }
+
+  bool MarkVariableHasWildCardPath() {
+    if (in_variable_ && !variables_.empty()) {
+      CurrentVariable().has_wildcard_path = true;
+      return true;
+    } else {
+      // something's wrong we're not in a variable
+      return false;
+    }
+  }
+
+  bool ValidateVariable(const HttpTemplate::Variable &var) {
+    return !var.field_path.empty() && (var.start_segment < var.end_segment) &&
+           (var.end_segment <= static_cast<int>(segments_.size()));
+  }
+
+  void PostProcessVariables() {
+    for (auto &var : variables_) {
+      if (var.has_wildcard_path) {
+        // if the variable contains a '**', store the end_positon
+        // relative to the end, such that -1 corresponds to the end
+        // of the path. As we only support fixed path after '**',
+        // this will allow the matcher code to reconstruct the variable
+        // value based on the url segments.
+        var.end_segment = (var.end_segment - segments_.size() - 1);
+
+        if (!verb_.empty()) {
+          // a custom verb will add an additional segment, so
+          // the end_postion needs a -1
+          --var.end_segment;
+        }
+      }
+    }
+  }
+
+  const std::string &input_;
+
+  // Token delimiter indexes
+  size_t tb_;
+  size_t te_;
+
+  // are we in nested Segments of a variable?
+  bool in_variable_;
+
+  std::vector<std::string> segments_;
+  std::string verb_;
+  std::vector<HttpTemplate::Variable> variables_;
+};
+
+}  // namespace
+
+const char HttpTemplate::kSingleParameterKey[] = "/.";
+
+const char HttpTemplate::kWildCardPathPartKey[] = "*";
+
+const char HttpTemplate::kWildCardPathKey[] = "**";
+
+HttpTemplate *HttpTemplate::Parse(const std::string &ht) {
+  Parser p(ht);
+  if (!p.Parse() || !p.ValidateParts()) {
+    return nullptr;
+  }
+
+  return new HttpTemplate(std::move(p.segments()), std::move(p.verb()),
+                          std::move(p.variables()));
+}
+
+}  // namespace api_spec
+}  // namespace istio

--- a/api_spec/src/http_template.h
+++ b/api_spec/src/http_template.h
@@ -16,6 +16,7 @@
 #ifndef API_SPEC_HTTP_TEMPLATE_H_
 #define API_SPEC_HTTP_TEMPLATE_H_
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -24,7 +25,7 @@ namespace api_spec {
 
 class HttpTemplate {
  public:
-  static HttpTemplate *Parse(const std::string &ht);
+  static std::unique_ptr<HttpTemplate> Parse(const std::string &ht);
   const std::vector<std::string> &segments() const { return segments_; }
   const std::string &verb() const { return verb_; }
 

--- a/api_spec/src/http_template.h
+++ b/api_spec/src/http_template.h
@@ -1,0 +1,71 @@
+/* Copyright 2017 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef API_SPEC_HTTP_TEMPLATE_H_
+#define API_SPEC_HTTP_TEMPLATE_H_
+
+#include <string>
+#include <vector>
+
+namespace istio {
+namespace api_spec {
+
+class HttpTemplate {
+ public:
+  static HttpTemplate *Parse(const std::string &ht);
+  const std::vector<std::string> &segments() const { return segments_; }
+  const std::string &verb() const { return verb_; }
+
+  // The info about a variable binding {variable=subpath} in the template.
+  struct Variable {
+    // Specifies the range of segments [start_segment, end_segment) the
+    // variable binds to. Both start_segment and end_segment are 0 based.
+    // end_segment can also be negative, which means that the position is
+    // specified relative to the end such that -1 corresponds to the end
+    // of the path.
+    int start_segment;
+    int end_segment;
+
+    // The path of the protobuf field the variable binds to.
+    std::vector<std::string> field_path;
+
+    // Do we have a ** in the variable template?
+    bool has_wildcard_path;
+  };
+
+  std::vector<Variable> &Variables() { return variables_; }
+
+  // '/.': match any single path segment.
+  static const char kSingleParameterKey[];
+  // '*': Wildcard match for one path segment.
+  static const char kWildCardPathPartKey[];
+  // '**': Wildcard match the remaining path.
+  static const char kWildCardPathKey[];
+
+ private:
+  HttpTemplate(std::vector<std::string> &&segments, std::string &&verb,
+               std::vector<Variable> &&variables)
+      : segments_(std::move(segments)),
+        verb_(std::move(verb)),
+        variables_(std::move(variables)) {}
+  const std::vector<std::string> segments_;
+  std::string verb_;
+  std::vector<Variable> variables_;
+};
+
+}  // namespace api_spec
+}  // namespace istio
+
+#endif  // API_SPEC_HTTP_TEMPLATE_H_

--- a/api_spec/src/http_template_test.cc
+++ b/api_spec/src/http_template_test.cc
@@ -1,0 +1,513 @@
+/* Copyright 2017 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "http_template.h"
+#include "gtest/gtest.h"
+
+#include <ostream>
+#include <string>
+#include <vector>
+
+namespace istio {
+namespace api_spec {
+
+typedef std::vector<std::string> Segments;
+typedef HttpTemplate::Variable Variable;
+typedef std::vector<Variable> Variables;
+typedef std::vector<std::string> FieldPath;
+
+bool operator==(const Variable &v1, const Variable &v2) {
+  return v1.field_path == v2.field_path &&
+         v1.start_segment == v2.start_segment &&
+         v1.end_segment == v2.end_segment &&
+         v1.has_wildcard_path == v2.has_wildcard_path;
+}
+
+std::string FieldPathToString(const FieldPath &fp) {
+  std::string s;
+  for (const auto &f : fp) {
+    if (!s.empty()) {
+      s += ".";
+    }
+    s += f;
+  }
+  return s;
+}
+
+std::ostream &operator<<(std::ostream &os, const Variable &var) {
+  return os << "{ " << FieldPathToString(var.field_path) << ", ["
+            << var.start_segment << ", " << var.end_segment << "), "
+            << var.has_wildcard_path << "}";
+}
+
+std::ostream &operator<<(std::ostream &os, const Variables &vars) {
+  for (const auto &var : vars) {
+    os << var << std::endl;
+  }
+  return os;
+}
+
+TEST(HttpTemplate, ParseTest1) {
+  HttpTemplate *ht = HttpTemplate::Parse("/shelves/{shelf}/books/{book}");
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"shelves", "*", "books", "*"}), ht->segments());
+  ASSERT_EQ(Variables({
+                Variable{1, 2, FieldPath{"shelf"}, false},
+                Variable{3, 4, FieldPath{"book"}, false},
+            }),
+            ht->Variables());
+}
+
+TEST(HttpTemplate, ParseTest2) {
+  HttpTemplate *ht = HttpTemplate::Parse("/shelves/**");
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"shelves", "**"}), ht->segments());
+  ASSERT_EQ("", ht->verb());
+  ASSERT_EQ(Variables({}), ht->Variables());
+}
+
+TEST(HttpTemplate, ParseTest3) {
+  HttpTemplate *ht = HttpTemplate::Parse("/**");
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"**"}), ht->segments());
+  ASSERT_EQ("", ht->verb());
+  ASSERT_EQ(Variables(), ht->Variables());
+}
+
+TEST(HttpTemplate, ParseTest4a) {
+  HttpTemplate *ht = HttpTemplate::Parse("/a:foo");
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"a"}), ht->segments());
+  ASSERT_EQ("foo", ht->verb());
+  ASSERT_EQ(Variables(), ht->Variables());
+}
+
+TEST(HttpTemplate, ParseTest4b) {
+  HttpTemplate *ht = HttpTemplate::Parse("/a/b/c:foo");
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"a", "b", "c"}), ht->segments());
+  ASSERT_EQ("foo", ht->verb());
+  ASSERT_EQ(Variables(), ht->Variables());
+}
+
+TEST(HttpTemplate, ParseTest5) {
+  HttpTemplate *ht = HttpTemplate::Parse("/*/**");
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"*", "**"}), ht->segments());
+  ASSERT_EQ("", ht->verb());
+  ASSERT_EQ(Variables(), ht->Variables());
+}
+
+TEST(HttpTemplate, ParseTest6) {
+  HttpTemplate *ht = HttpTemplate::Parse("/*/a/**");
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"*", "a", "**"}), ht->segments());
+  ASSERT_EQ("", ht->verb());
+  ASSERT_EQ(Variables(), ht->Variables());
+}
+
+TEST(HttpTemplate, ParseTest7) {
+  HttpTemplate *ht = HttpTemplate::Parse("/a/{a.b.c}");
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"a", "*"}), ht->segments());
+  ASSERT_EQ("", ht->verb());
+  ASSERT_EQ(Variables({
+                Variable{1, 2, FieldPath{"a", "b", "c"}, false},
+            }),
+            ht->Variables());
+}
+
+TEST(HttpTemplate, ParseTest8) {
+  HttpTemplate *ht = HttpTemplate::Parse("/a/{a.b.c=*}");
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"a", "*"}), ht->segments());
+  ASSERT_EQ("", ht->verb());
+  ASSERT_EQ(Variables({
+                Variable{1, 2, FieldPath{"a", "b", "c"}, false},
+            }),
+            ht->Variables());
+}
+
+TEST(HttpTemplate, ParseTest9) {
+  HttpTemplate *ht = HttpTemplate::Parse("/a/{b=*}");
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"a", "*"}), ht->segments());
+  ASSERT_EQ("", ht->verb());
+  ASSERT_EQ(Variables({
+                Variable{1, 2, FieldPath{"b"}, false},
+            }),
+            ht->Variables());
+}
+
+TEST(HttpTemplate, ParseTest10) {
+  HttpTemplate *ht = HttpTemplate::Parse("/a/{b=**}");
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"a", "**"}), ht->segments());
+  ASSERT_EQ("", ht->verb());
+  ASSERT_EQ(Variables({
+                Variable{1, -1, FieldPath{"b"}, true},
+            }),
+            ht->Variables());
+}
+
+TEST(HttpTemplate, ParseTest11) {
+  HttpTemplate *ht = HttpTemplate::Parse("/a/{b=c/*}");
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"a", "c", "*"}), ht->segments());
+  ASSERT_EQ("", ht->verb());
+  ASSERT_EQ(Variables({
+                Variable{1, 3, FieldPath{"b"}, false},
+            }),
+            ht->Variables());
+}
+
+TEST(HttpTemplate, ParseTest12) {
+  HttpTemplate *ht = HttpTemplate::Parse("/a/{b=c/*/d}");
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"a", "c", "*", "d"}), ht->segments());
+  ASSERT_EQ("", ht->verb());
+  ASSERT_EQ(Variables({
+                Variable{1, 4, FieldPath{"b"}, false},
+            }),
+            ht->Variables());
+}
+
+TEST(HttpTemplate, ParseTest13) {
+  HttpTemplate *ht = HttpTemplate::Parse("/a/{b=c/**}");
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"a", "c", "**"}), ht->segments());
+  ASSERT_EQ("", ht->verb());
+  ASSERT_EQ(Variables({
+                Variable{1, -1, FieldPath{"b"}, true},
+            }),
+            ht->Variables());
+}
+
+TEST(HttpTemplate, ParseTest14) {
+  HttpTemplate *ht = HttpTemplate::Parse("/a/{b=c/**}/d/e");
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"a", "c", "**", "d", "e"}), ht->segments());
+  ASSERT_EQ("", ht->verb());
+  ASSERT_EQ(Variables({
+                Variable{1, -3, FieldPath{"b"}, true},
+            }),
+            ht->Variables());
+}
+
+TEST(HttpTemplate, ParseTest15) {
+  HttpTemplate *ht = HttpTemplate::Parse("/a/{b=c/**/d}/e");
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"a", "c", "**", "d", "e"}), ht->segments());
+  ASSERT_EQ("", ht->verb());
+  ASSERT_EQ(Variables({
+                Variable{1, -2, FieldPath{"b"}, true},
+            }),
+            ht->Variables());
+}
+
+TEST(HttpTemplate, ParseTest16) {
+  HttpTemplate *ht = HttpTemplate::Parse("/a/{b=c/**/d}/e:verb");
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"a", "c", "**", "d", "e"}), ht->segments());
+  ASSERT_EQ("verb", ht->verb());
+  ASSERT_EQ(Variables({
+                Variable{1, -3, FieldPath{"b"}, true},
+            }),
+            ht->Variables());
+}
+
+TEST(HttpTemplate, CustomVerbTests) {
+  HttpTemplate *ht;
+
+  ht = HttpTemplate::Parse("/*:verb");
+  ASSERT_EQ(Segments({"*"}), ht->segments());
+  ASSERT_EQ(Variables(), ht->Variables());
+
+  ht = HttpTemplate::Parse("/**:verb");
+  ASSERT_EQ(Segments({"**"}), ht->segments());
+  ASSERT_EQ(Variables(), ht->Variables());
+
+  ht = HttpTemplate::Parse("/{a}:verb");
+  ASSERT_EQ(Segments({"*"}), ht->segments());
+  ASSERT_EQ(Variables({
+                Variable{0, 1, FieldPath{"a"}, false},
+            }),
+            ht->Variables());
+
+  ht = HttpTemplate::Parse("/a/b/*:verb");
+  ASSERT_EQ(Segments({"a", "b", "*"}), ht->segments());
+  ASSERT_EQ(Variables(), ht->Variables());
+
+  ht = HttpTemplate::Parse("/a/b/**:verb");
+  ASSERT_EQ(Segments({"a", "b", "**"}), ht->segments());
+  ASSERT_EQ(Variables(), ht->Variables());
+
+  ht = HttpTemplate::Parse("/a/b/{a}:verb");
+  ASSERT_EQ(Segments({"a", "b", "*"}), ht->segments());
+  ASSERT_EQ(Variables({
+                Variable{2, 3, FieldPath{"a"}, false},
+            }),
+            ht->Variables());
+}
+
+TEST(HttpTemplate, MoreVariableTests) {
+  HttpTemplate *ht = HttpTemplate::Parse("/{x}");
+
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"*"}), ht->segments());
+  ASSERT_EQ("", ht->verb());
+  ASSERT_EQ(Variables({
+                Variable{0, 1, FieldPath{"x"}, false},
+            }),
+            ht->Variables());
+
+  ht = HttpTemplate::Parse("/{x.y.z}");
+
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"*"}), ht->segments());
+  ASSERT_EQ("", ht->verb());
+  ASSERT_EQ(Variables({
+                Variable{0, 1, FieldPath{"x", "y", "z"}, false},
+            }),
+            ht->Variables());
+
+  ht = HttpTemplate::Parse("/{x=*}");
+
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"*"}), ht->segments());
+  ASSERT_EQ("", ht->verb());
+  ASSERT_EQ(Variables({
+                Variable{0, 1, FieldPath{"x"}, false},
+            }),
+            ht->Variables());
+
+  ht = HttpTemplate::Parse("/{x=a/*}");
+
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"a", "*"}), ht->segments());
+  ASSERT_EQ("", ht->verb());
+  ASSERT_EQ(Variables({
+                Variable{0, 2, FieldPath{"x"}, false},
+            }),
+            ht->Variables());
+
+  ht = HttpTemplate::Parse("/{x.y.z=*/a/b}/c");
+
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"*", "a", "b", "c"}), ht->segments());
+  ASSERT_EQ("", ht->verb());
+  ASSERT_EQ(Variables({
+                Variable{0, 3, FieldPath{"x", "y", "z"}, false},
+            }),
+            ht->Variables());
+
+  ht = HttpTemplate::Parse("/{x=**}");
+
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"**"}), ht->segments());
+  ASSERT_EQ("", ht->verb());
+  ASSERT_EQ(Variables({
+                Variable{0, -1, FieldPath{"x"}, true},
+            }),
+            ht->Variables());
+
+  ht = HttpTemplate::Parse("/{x.y.z=**}");
+
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"**"}), ht->segments());
+  ASSERT_EQ("", ht->verb());
+  ASSERT_EQ(Variables({
+                Variable{0, -1, FieldPath{"x", "y", "z"}, true},
+            }),
+            ht->Variables());
+
+  ht = HttpTemplate::Parse("/{x.y.z=a/**/b}");
+
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"a", "**", "b"}), ht->segments());
+  ASSERT_EQ("", ht->verb());
+  ASSERT_EQ(Variables({
+                Variable{0, -1, FieldPath{"x", "y", "z"}, true},
+            }),
+            ht->Variables());
+
+  ht = HttpTemplate::Parse("/{x.y.z=a/**/b}/c/d");
+
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"a", "**", "b", "c", "d"}), ht->segments());
+  ASSERT_EQ("", ht->verb());
+  ASSERT_EQ(Variables({
+                Variable{0, -3, FieldPath{"x", "y", "z"}, true},
+            }),
+            ht->Variables());
+}
+
+TEST(HttpTemplate, VariableAndCustomVerbTests) {
+  HttpTemplate *ht = HttpTemplate::Parse("/{x}:verb");
+
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"*"}), ht->segments());
+  ASSERT_EQ("verb", ht->verb());
+  ASSERT_EQ(Variables({
+                Variable{0, 1, FieldPath{"x"}, false},
+            }),
+            ht->Variables());
+
+  ht = HttpTemplate::Parse("/{x.y.z}:verb");
+
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"*"}), ht->segments());
+  ASSERT_EQ("verb", ht->verb());
+  ASSERT_EQ(Variables({
+                Variable{0, 1, FieldPath{"x", "y", "z"}, false},
+            }),
+            ht->Variables());
+
+  ht = HttpTemplate::Parse("/{x.y.z=*/*}:verb");
+
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"*", "*"}), ht->segments());
+  ASSERT_EQ("verb", ht->verb());
+  ASSERT_EQ(Variables({
+                Variable{0, 2, FieldPath{"x", "y", "z"}, false},
+            }),
+            ht->Variables());
+
+  ht = HttpTemplate::Parse("/{x=**}:myverb");
+
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"**"}), ht->segments());
+  ASSERT_EQ("myverb", ht->verb());
+  ASSERT_EQ(Variables({
+                Variable{0, -2, FieldPath{"x"}, true},
+            }),
+            ht->Variables());
+
+  ht = HttpTemplate::Parse("/{x.y.z=**}:myverb");
+
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"**"}), ht->segments());
+  ASSERT_EQ("myverb", ht->verb());
+  ASSERT_EQ(Variables({
+                Variable{0, -2, FieldPath{"x", "y", "z"}, true},
+            }),
+            ht->Variables());
+
+  ht = HttpTemplate::Parse("/{x.y.z=a/**/b}:custom");
+
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"a", "**", "b"}), ht->segments());
+  ASSERT_EQ("custom", ht->verb());
+  ASSERT_EQ(Variables({
+                Variable{0, -2, FieldPath{"x", "y", "z"}, true},
+            }),
+            ht->Variables());
+
+  ht = HttpTemplate::Parse("/{x.y.z=a/**/b}/c/d:custom");
+
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(Segments({"a", "**", "b", "c", "d"}), ht->segments());
+  ASSERT_EQ("custom", ht->verb());
+  ASSERT_EQ(Variables({
+                Variable{0, -4, FieldPath{"x", "y", "z"}, true},
+            }),
+            ht->Variables());
+}
+
+TEST(HttpTemplate, ErrorTests) {
+  ASSERT_EQ(nullptr, HttpTemplate::Parse(""));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("//"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/{}"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/a/"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/a//b"));
+
+  ASSERT_EQ(nullptr, HttpTemplate::Parse(":verb"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/:verb"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/a/:verb"));
+
+  ASSERT_EQ(nullptr, HttpTemplate::Parse(":"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/:"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/*:"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/**:"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/{var}:"));
+
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/a/b/:"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/a/b/*:"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/a/b/**:"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/a/b/{var}:"));
+
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/a/{"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/a/{var"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/a/{var."));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/a/{x=var:verb}"));
+
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("a"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("{x}"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("{x=/a}"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("{x=/a/b}"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("a/b"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("a/b/{x}"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("a/{x}/b"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("a/{x}/b:verb"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/a/{var=/b}"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/{var=a/{nested=b}}"));
+
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/a{x}"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/{x}a"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/a{x}b"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/{x}a{y}"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/a/b{x}"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/a/{x}b"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/a/b{x}c"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/a/{x}b{y}"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/a/b{x}/s"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/a/{x}b/s"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/a/b{x}c/s"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/a/{x}b{y}/s"));
+}
+
+TEST(HttpTemplate, ParseVerbTest2) {
+  HttpTemplate *ht = HttpTemplate::Parse("/a/*:verb");
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(ht->segments(), Segments({"a", "*"}));
+  ASSERT_EQ("verb", ht->verb());
+}
+
+TEST(HttpTemplate, ParseVerbTest3) {
+  HttpTemplate *ht = HttpTemplate::Parse("/a/**:verb");
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(ht->segments(), Segments({"a", "**"}));
+  ASSERT_EQ("verb", ht->verb());
+}
+
+TEST(HttpTemplate, ParseVerbTest4) {
+  HttpTemplate *ht = HttpTemplate::Parse("/a/{b=*}/**:verb");
+  ASSERT_NE(nullptr, ht);
+  ASSERT_EQ(ht->segments(), Segments({"a", "*", "**"}));
+  ASSERT_EQ("verb", ht->verb());
+}
+
+TEST(HttpTemplate, ParseNonVerbTest) {
+  ASSERT_EQ(nullptr, HttpTemplate::Parse(":"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/:"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/a/:"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/a/*:"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/a/**:"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/a/{b=*}/**:"));
+}
+
+}  // namespace api_spec
+}  // namespace istio

--- a/api_spec/src/http_template_test.cc
+++ b/api_spec/src/http_template_test.cc
@@ -60,7 +60,7 @@ std::ostream &operator<<(std::ostream &os, const Variables &vars) {
 }
 
 TEST(HttpTemplate, ParseTest1) {
-  HttpTemplate *ht = HttpTemplate::Parse("/shelves/{shelf}/books/{book}");
+  auto ht = HttpTemplate::Parse("/shelves/{shelf}/books/{book}");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"shelves", "*", "books", "*"}), ht->segments());
   ASSERT_EQ(Variables({
@@ -71,7 +71,7 @@ TEST(HttpTemplate, ParseTest1) {
 }
 
 TEST(HttpTemplate, ParseTest2) {
-  HttpTemplate *ht = HttpTemplate::Parse("/shelves/**");
+  auto ht = HttpTemplate::Parse("/shelves/**");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"shelves", "**"}), ht->segments());
   ASSERT_EQ("", ht->verb());
@@ -79,7 +79,7 @@ TEST(HttpTemplate, ParseTest2) {
 }
 
 TEST(HttpTemplate, ParseTest3) {
-  HttpTemplate *ht = HttpTemplate::Parse("/**");
+  auto ht = HttpTemplate::Parse("/**");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"**"}), ht->segments());
   ASSERT_EQ("", ht->verb());
@@ -87,7 +87,7 @@ TEST(HttpTemplate, ParseTest3) {
 }
 
 TEST(HttpTemplate, ParseTest4a) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a:foo");
+  auto ht = HttpTemplate::Parse("/a:foo");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"a"}), ht->segments());
   ASSERT_EQ("foo", ht->verb());
@@ -95,7 +95,7 @@ TEST(HttpTemplate, ParseTest4a) {
 }
 
 TEST(HttpTemplate, ParseTest4b) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a/b/c:foo");
+  auto ht = HttpTemplate::Parse("/a/b/c:foo");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"a", "b", "c"}), ht->segments());
   ASSERT_EQ("foo", ht->verb());
@@ -103,7 +103,7 @@ TEST(HttpTemplate, ParseTest4b) {
 }
 
 TEST(HttpTemplate, ParseTest5) {
-  HttpTemplate *ht = HttpTemplate::Parse("/*/**");
+  auto ht = HttpTemplate::Parse("/*/**");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"*", "**"}), ht->segments());
   ASSERT_EQ("", ht->verb());
@@ -111,7 +111,7 @@ TEST(HttpTemplate, ParseTest5) {
 }
 
 TEST(HttpTemplate, ParseTest6) {
-  HttpTemplate *ht = HttpTemplate::Parse("/*/a/**");
+  auto ht = HttpTemplate::Parse("/*/a/**");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"*", "a", "**"}), ht->segments());
   ASSERT_EQ("", ht->verb());
@@ -119,7 +119,7 @@ TEST(HttpTemplate, ParseTest6) {
 }
 
 TEST(HttpTemplate, ParseTest7) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a/{a.b.c}");
+  auto ht = HttpTemplate::Parse("/a/{a.b.c}");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"a", "*"}), ht->segments());
   ASSERT_EQ("", ht->verb());
@@ -130,7 +130,7 @@ TEST(HttpTemplate, ParseTest7) {
 }
 
 TEST(HttpTemplate, ParseTest8) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a/{a.b.c=*}");
+  auto ht = HttpTemplate::Parse("/a/{a.b.c=*}");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"a", "*"}), ht->segments());
   ASSERT_EQ("", ht->verb());
@@ -141,7 +141,7 @@ TEST(HttpTemplate, ParseTest8) {
 }
 
 TEST(HttpTemplate, ParseTest9) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a/{b=*}");
+  auto ht = HttpTemplate::Parse("/a/{b=*}");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"a", "*"}), ht->segments());
   ASSERT_EQ("", ht->verb());
@@ -152,7 +152,7 @@ TEST(HttpTemplate, ParseTest9) {
 }
 
 TEST(HttpTemplate, ParseTest10) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a/{b=**}");
+  auto ht = HttpTemplate::Parse("/a/{b=**}");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"a", "**"}), ht->segments());
   ASSERT_EQ("", ht->verb());
@@ -163,7 +163,7 @@ TEST(HttpTemplate, ParseTest10) {
 }
 
 TEST(HttpTemplate, ParseTest11) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a/{b=c/*}");
+  auto ht = HttpTemplate::Parse("/a/{b=c/*}");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"a", "c", "*"}), ht->segments());
   ASSERT_EQ("", ht->verb());
@@ -174,7 +174,7 @@ TEST(HttpTemplate, ParseTest11) {
 }
 
 TEST(HttpTemplate, ParseTest12) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a/{b=c/*/d}");
+  auto ht = HttpTemplate::Parse("/a/{b=c/*/d}");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"a", "c", "*", "d"}), ht->segments());
   ASSERT_EQ("", ht->verb());
@@ -185,7 +185,7 @@ TEST(HttpTemplate, ParseTest12) {
 }
 
 TEST(HttpTemplate, ParseTest13) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a/{b=c/**}");
+  auto ht = HttpTemplate::Parse("/a/{b=c/**}");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"a", "c", "**"}), ht->segments());
   ASSERT_EQ("", ht->verb());
@@ -196,7 +196,7 @@ TEST(HttpTemplate, ParseTest13) {
 }
 
 TEST(HttpTemplate, ParseTest14) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a/{b=c/**}/d/e");
+  auto ht = HttpTemplate::Parse("/a/{b=c/**}/d/e");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"a", "c", "**", "d", "e"}), ht->segments());
   ASSERT_EQ("", ht->verb());
@@ -207,7 +207,7 @@ TEST(HttpTemplate, ParseTest14) {
 }
 
 TEST(HttpTemplate, ParseTest15) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a/{b=c/**/d}/e");
+  auto ht = HttpTemplate::Parse("/a/{b=c/**/d}/e");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"a", "c", "**", "d", "e"}), ht->segments());
   ASSERT_EQ("", ht->verb());
@@ -218,7 +218,7 @@ TEST(HttpTemplate, ParseTest15) {
 }
 
 TEST(HttpTemplate, ParseTest16) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a/{b=c/**/d}/e:verb");
+  auto ht = HttpTemplate::Parse("/a/{b=c/**/d}/e:verb");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"a", "c", "**", "d", "e"}), ht->segments());
   ASSERT_EQ("verb", ht->verb());
@@ -229,9 +229,7 @@ TEST(HttpTemplate, ParseTest16) {
 }
 
 TEST(HttpTemplate, CustomVerbTests) {
-  HttpTemplate *ht;
-
-  ht = HttpTemplate::Parse("/*:verb");
+  auto ht = HttpTemplate::Parse("/*:verb");
   ASSERT_EQ(Segments({"*"}), ht->segments());
   ASSERT_EQ(Variables(), ht->Variables());
 
@@ -263,7 +261,7 @@ TEST(HttpTemplate, CustomVerbTests) {
 }
 
 TEST(HttpTemplate, MoreVariableTests) {
-  HttpTemplate *ht = HttpTemplate::Parse("/{x}");
+  auto ht = HttpTemplate::Parse("/{x}");
 
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"*"}), ht->segments());
@@ -355,7 +353,7 @@ TEST(HttpTemplate, MoreVariableTests) {
 }
 
 TEST(HttpTemplate, VariableAndCustomVerbTests) {
-  HttpTemplate *ht = HttpTemplate::Parse("/{x}:verb");
+  auto ht = HttpTemplate::Parse("/{x}:verb");
 
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"*"}), ht->segments());
@@ -480,21 +478,21 @@ TEST(HttpTemplate, ErrorTests) {
 }
 
 TEST(HttpTemplate, ParseVerbTest2) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a/*:verb");
+  auto ht = HttpTemplate::Parse("/a/*:verb");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(ht->segments(), Segments({"a", "*"}));
   ASSERT_EQ("verb", ht->verb());
 }
 
 TEST(HttpTemplate, ParseVerbTest3) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a/**:verb");
+  auto ht = HttpTemplate::Parse("/a/**:verb");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(ht->segments(), Segments({"a", "**"}));
   ASSERT_EQ("verb", ht->verb());
 }
 
 TEST(HttpTemplate, ParseVerbTest4) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a/{b=*}/**:verb");
+  auto ht = HttpTemplate::Parse("/a/{b=*}/**:verb");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(ht->segments(), Segments({"a", "*", "**"}));
   ASSERT_EQ("verb", ht->verb());

--- a/api_spec/src/path_matcher.h
+++ b/api_spec/src/path_matcher.h
@@ -1,0 +1,498 @@
+/* Copyright 2017 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef API_SPEC_PATH_MATCHER_H_
+#define API_SPEC_PATH_MATCHER_H_
+
+#include <cstddef>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+
+#include "http_template.h"
+#include "path_matcher_node.h"
+
+namespace istio {
+namespace api_spec {
+
+template <class Method>
+class PathMatcherBuilder;  // required for PathMatcher constructor
+
+// The immutable, thread safe PathMatcher stores a mapping from a combination of
+// a service (host) name and a HTTP path to your method (MethodInfo*). It is
+// constructed with a PathMatcherBuilder and supports one operation: Lookup.
+// Clients may use this method to locate your method (MethodInfo*) for a
+// combination of service name and HTTP URL path.
+//
+// Usage example:
+// 1) building the PathMatcher:
+//     PathMatcherBuilder builder(false);
+//     for each (service_name, http_method, url_path, associated method)
+//         builder.register(service_name, http_method, url_path, data);
+//     PathMater matcher = builder.Build();
+// 2) lookup:
+//      MethodInfo * method = matcher.Lookup(service_name, http_method,
+//                                           url_path);
+//      if (method == nullptr)  failed to find it.
+//
+template <class Method>
+class PathMatcher {
+ public:
+  ~PathMatcher(){};
+
+  // TODO: Do not template VariableBinding
+  template <class VariableBinding>
+  Method Lookup(const std::string& http_method, const std::string& path,
+                const std::string& query_params,
+                std::vector<VariableBinding>* variable_bindings,
+                std::string* body_field_path) const;
+
+  Method Lookup(const std::string& http_method, const std::string& path) const;
+
+ private:
+  // Creates a Path Matcher with a Builder by moving the builder's root node.
+  explicit PathMatcher(PathMatcherBuilder<Method>&& builder);
+
+  // A root node shared by all services, i.e. paths of all services will be
+  // registered to this node.
+  std::unique_ptr<PathMatcherNode> root_ptr_;
+  // Holds the set of custom verbs found in configured templates.
+  std::set<std::string> custom_verbs_;
+  // Data we store per each registered method
+  struct MethodData {
+    Method method;
+    std::vector<HttpTemplate::Variable> variables;
+    std::string body_field_path;
+  };
+  // The info associated with each method. The path matcher nodes
+  // will hold pointers to MethodData objects in this vector.
+  std::vector<std::unique_ptr<MethodData>> methods_;
+
+ private:
+  friend class PathMatcherBuilder<Method>;
+};
+
+template <class Method>
+using PathMatcherPtr = std::unique_ptr<PathMatcher<Method>>;
+
+// This PathMatcherBuilder is used to register path-WrapperGraph pairs and
+// instantiate an immutable, thread safe PathMatcher.
+//
+// The PathMatcherBuilder itself is NOT THREAD SAFE.
+template <class Method>
+class PathMatcherBuilder {
+ public:
+  PathMatcherBuilder();
+  ~PathMatcherBuilder() {}
+
+  // Registers a method.
+  //
+  // Registrations are one-to-one. If this function is called more than once, it
+  // replaces the existing method. Only the last registered method is stored.
+  // Return false if path is an invalid http template.
+  bool Register(std::string http_method, std::string path,
+                std::string body_field_path, Method method);
+
+  // Returns a unique_ptr to a thread safe PathMatcher that contains all
+  // registered path-WrapperGraph pairs. Note the PathMatchBuilder instance
+  // will be moved so cannot use after invoking Build().
+  PathMatcherPtr<Method> Build();
+
+ private:
+  // A root node shared by all services, i.e. paths of all services will be
+  // registered to this node.
+  std::unique_ptr<PathMatcherNode> root_ptr_;
+  // The set of custom verbs configured.
+  // TODO: Perhaps this should not be at this level because there will
+  // be multiple templates in different services on a server. Consider moving
+  // this to PathMatcherNode.
+  std::set<std::string> custom_verbs_;
+  typedef typename PathMatcher<Method>::MethodData MethodData;
+  std::vector<std::unique_ptr<MethodData>> methods_;
+
+  friend class PathMatcher<Method>;
+};
+
+namespace {
+
+std::vector<std::string>& split(const std::string& s, char delim,
+                                std::vector<std::string>& elems) {
+  std::stringstream ss(s);
+  std::string item;
+  while (std::getline(ss, item, delim)) {
+    elems.push_back(item);
+  }
+  return elems;
+}
+
+inline bool IsReservedChar(char c) {
+  // Reserved characters according to RFC 6570
+  switch (c) {
+    case '!':
+    case '#':
+    case '$':
+    case '&':
+    case '\'':
+    case '(':
+    case ')':
+    case '*':
+    case '+':
+    case ',':
+    case '/':
+    case ':':
+    case ';':
+    case '=':
+    case '?':
+    case '@':
+    case '[':
+    case ']':
+      return true;
+    default:
+      return false;
+  }
+}
+
+// Check if an ASCII character is a hex digit.  We can't use ctype's
+// isxdigit() because it is affected by locale. This function is applied
+// to the escaped characters in a url, not to natural-language
+// strings, so locale should not be taken into account.
+inline bool ascii_isxdigit(char c) {
+  return ('a' <= c && c <= 'f') || ('A' <= c && c <= 'F') ||
+         ('0' <= c && c <= '9');
+}
+
+inline int hex_digit_to_int(char c) {
+  /* Assume ASCII. */
+  int x = static_cast<unsigned char>(c);
+  if (x > '9') {
+    x += 9;
+  }
+  return x & 0xf;
+}
+
+// This is a helper function for UrlUnescapeString. It takes a string and
+// the index of where we are within that string.
+//
+// The function returns true if the next three characters are of the format:
+// "%[0-9A-Fa-f]{2}".
+//
+// If the next three characters are an escaped character then this function will
+// also return what character is escaped.
+bool GetEscapedChar(const std::string& src, size_t i,
+                    bool unescape_reserved_chars, char* out) {
+  if (i + 2 < src.size() && src[i] == '%') {
+    if (ascii_isxdigit(src[i + 1]) && ascii_isxdigit(src[i + 2])) {
+      char c =
+          (hex_digit_to_int(src[i + 1]) << 4) | hex_digit_to_int(src[i + 2]);
+      if (!unescape_reserved_chars && IsReservedChar(c)) {
+        return false;
+      }
+      *out = c;
+      return true;
+    }
+  }
+  return false;
+}
+
+// Unescapes string 'part' and returns the unescaped string. Reserved characters
+// (as specified in RFC 6570) are not escaped if unescape_reserved_chars is
+// false.
+std::string UrlUnescapeString(const std::string& part,
+                              bool unescape_reserved_chars) {
+  std::string unescaped;
+  // Check whether we need to escape at all.
+  bool needs_unescaping = false;
+  char ch = '\0';
+  for (size_t i = 0; i < part.size(); ++i) {
+    if (GetEscapedChar(part, i, unescape_reserved_chars, &ch)) {
+      needs_unescaping = true;
+      break;
+    }
+  }
+  if (!needs_unescaping) {
+    unescaped = part;
+    return unescaped;
+  }
+
+  unescaped.resize(part.size());
+
+  char* begin = &(unescaped)[0];
+  char* p = begin;
+
+  for (size_t i = 0; i < part.size();) {
+    if (GetEscapedChar(part, i, unescape_reserved_chars, &ch)) {
+      *p++ = ch;
+      i += 3;
+    } else {
+      *p++ = part[i];
+      i += 1;
+    }
+  }
+
+  unescaped.resize(p - begin);
+  return unescaped;
+}
+
+template <class VariableBinding>
+void ExtractBindingsFromPath(const std::vector<HttpTemplate::Variable>& vars,
+                             const std::vector<std::string>& parts,
+                             std::vector<VariableBinding>* bindings) {
+  for (const auto& var : vars) {
+    // Determine the subpath bound to the variable based on the
+    // [start_segment, end_segment) segment range of the variable.
+    //
+    // In case of matching "**" - end_segment is negative and is relative to
+    // the end such that end_segment = -1 will match all subsequent segments.
+    VariableBinding binding;
+    binding.field_path = var.field_path;
+    // Calculate the absolute index of the ending segment in case it's negative.
+    size_t end_segment = (var.end_segment >= 0)
+                             ? var.end_segment
+                             : parts.size() + var.end_segment + 1;
+    // It is multi-part match if we have more than one segment. We also make
+    // sure that a single URL segment match with ** is also considered a
+    // multi-part match by checking if it->second.end_segment is negative.
+    bool is_multipart =
+        (end_segment - var.start_segment) > 1 || var.end_segment < 0;
+    // Joins parts with "/"  to form a path string.
+    for (size_t i = var.start_segment; i < end_segment; ++i) {
+      // For multipart matches only unescape non-reserved characters.
+      binding.value += UrlUnescapeString(parts[i], !is_multipart);
+      if (i < end_segment - 1) {
+        binding.value += "/";
+      }
+    }
+    bindings->emplace_back(binding);
+  }
+}
+
+template <class VariableBinding>
+void ExtractBindingsFromQueryParameters(
+    const std::string& query_params, const std::set<std::string>& system_params,
+    std::vector<VariableBinding>* bindings) {
+  // The bindings in URL the query parameters have the following form:
+  //      <field_path1>=value1&<field_path2>=value2&...&<field_pathN>=valueN
+  // Query parameters may also contain system parameters such as `api_key`.
+  // We'll need to ignore these. Example:
+  //      book.id=123&book.author=Neal%20Stephenson&api_key=AIzaSyAz7fhBkC35D2M
+  std::vector<std::string> params;
+  split(query_params, '&', params);
+  for (const auto& param : params) {
+    size_t pos = param.find('=');
+    if (pos != 0 && pos != std::string::npos) {
+      auto name = param.substr(0, pos);
+      // Make sure the query parameter is not a system parameter (e.g.
+      // `api_key`) before adding the binding.
+      if (system_params.find(name) == std::end(system_params)) {
+        // The name of the parameter is a field path, which is a dot-delimited
+        // sequence of field names that identify the (potentially deep) field
+        // in the request, e.g. `book.author.name`.
+        VariableBinding binding;
+        split(name, '.', binding.field_path);
+        binding.value = UrlUnescapeString(param.substr(pos + 1), true);
+        bindings->emplace_back(std::move(binding));
+      }
+    }
+  }
+}
+
+// Converts a request path into a format that can be used to perform a request
+// lookup in the PathMatcher trie. This utility method sanitizes the request
+// path and then splits the path into slash separated parts. Returns an empty
+// vector if the sanitized path is "/".
+//
+// custom_verbs is a set of configured custom verbs that are used to match
+// against any custom verbs in request path. If the request_path contains a
+// custom verb not found in custom_verbs, it is treated as a part of the path.
+//
+// - Strips off query string: "/a?foo=bar" --> "/a"
+// - Collapses extra slashes: "///" --> "/"
+std::vector<std::string> ExtractRequestParts(
+    std::string path, const std::set<std::string>& custom_verbs) {
+  // Remove query parameters.
+  path = path.substr(0, path.find_first_of('?'));
+
+  // Replace last ':' with '/' to handle custom verb.
+  // But not for /foo:bar/const.
+  std::size_t last_colon_pos = path.find_last_of(':');
+  std::size_t last_slash_pos = path.find_last_of('/');
+  if (last_colon_pos != std::string::npos && last_colon_pos > last_slash_pos) {
+    std::string verb = path.substr(last_colon_pos + 1);
+    // only verb in the configured custom verbs, treat it as verb
+    // replace ":" with / as a separate segment.
+    if (custom_verbs.find(verb) != custom_verbs.end()) {
+      path[last_colon_pos] = '/';
+    }
+  }
+
+  std::vector<std::string> result;
+  if (path.size() > 0) {
+    split(path.substr(1), '/', result);
+  }
+  // Removes all trailing empty parts caused by extra "/".
+  while (!result.empty() && (*(--result.end())).empty()) {
+    result.pop_back();
+  }
+  return result;
+}
+
+// Looks up on a PathMatcherNode.
+PathMatcherLookupResult LookupInPathMatcherNode(
+    const PathMatcherNode& root, const std::vector<std::string>& parts,
+    const HttpMethod& http_method) {
+  PathMatcherLookupResult result;
+  root.LookupPath(parts.begin(), parts.end(), http_method, &result);
+  return result;
+}
+
+PathMatcherNode::PathInfo TransformHttpTemplate(const HttpTemplate& ht) {
+  PathMatcherNode::PathInfo::Builder builder;
+
+  for (const std::string& part : ht.segments()) {
+    builder.AppendLiteralNode(part);
+  }
+  if (!ht.verb().empty()) {
+    builder.AppendLiteralNode(ht.verb());
+  }
+
+  return builder.Build();
+}
+
+}  // namespace
+
+template <class Method>
+PathMatcher<Method>::PathMatcher(PathMatcherBuilder<Method>&& builder)
+    : root_ptr_(std::move(builder.root_ptr_)),
+      custom_verbs_(std::move(builder.custom_verbs_)),
+      methods_(std::move(builder.methods_)) {}
+
+// Lookup is a wrapper method for the recursive node Lookup. First, the wrapper
+// splits the request path into slash-separated path parts. Next, the method
+// checks that the |http_method| is supported. If not, then it returns an empty
+// WrapperGraph::SharedPtr. Next, this method invokes the node's Lookup on
+// the extracted |parts|. Finally, it fills the mapping from variables to their
+// values parsed from the path.
+// TODO: cache results by adding get/put methods here (if profiling reveals
+// benefit)
+template <class Method>
+template <class VariableBinding>
+Method PathMatcher<Method>::Lookup(
+    const std::string& http_method, const std::string& path,
+    const std::string& query_params,
+    std::vector<VariableBinding>* variable_bindings,
+    std::string* body_field_path) const {
+  const std::vector<std::string> parts =
+      ExtractRequestParts(path, custom_verbs_);
+
+  // If service_name has not been registered to ESP and strict_service_matching_
+  // is set to false, tries to lookup the method in all registered services.
+  if (root_ptr_ == nullptr) {
+    return nullptr;
+  }
+
+  PathMatcherLookupResult lookup_result =
+      LookupInPathMatcherNode(*root_ptr_, parts, http_method);
+  // Return nullptr if nothing is found.
+  // Not need to check duplication. Only first item is stored for duplicated
+  if (lookup_result.data == nullptr) {
+    return nullptr;
+  }
+  MethodData* method_data = reinterpret_cast<MethodData*>(lookup_result.data);
+  if (variable_bindings != nullptr) {
+    variable_bindings->clear();
+    ExtractBindingsFromPath(method_data->variables, parts, variable_bindings);
+    ExtractBindingsFromQueryParameters(
+        query_params, method_data->method->system_query_parameter_names(),
+        variable_bindings);
+  }
+  if (body_field_path != nullptr) {
+    *body_field_path = method_data->body_field_path;
+  }
+  return method_data->method;
+}
+
+// TODO: refactor common code with method above
+template <class Method>
+Method PathMatcher<Method>::Lookup(const std::string& http_method,
+                                   const std::string& path) const {
+  const std::vector<std::string> parts =
+      ExtractRequestParts(path, custom_verbs_);
+
+  // If service_name has not been registered to ESP and strict_service_matching_
+  // is set to false, tries to lookup the method in all registered services.
+  if (root_ptr_ == nullptr) {
+    return nullptr;
+  }
+
+  PathMatcherLookupResult lookup_result =
+      LookupInPathMatcherNode(*root_ptr_, parts, http_method);
+  // Return nullptr if nothing is found.
+  // Not need to check duplication. Only first item is stored for duplicated
+  if (lookup_result.data == nullptr) {
+    return nullptr;
+  }
+  MethodData* method_data = reinterpret_cast<MethodData*>(lookup_result.data);
+  return method_data->method;
+}
+
+// Initializes the builder with a root Path Segment
+template <class Method>
+PathMatcherBuilder<Method>::PathMatcherBuilder()
+    : root_ptr_(new PathMatcherNode()) {}
+
+template <class Method>
+PathMatcherPtr<Method> PathMatcherBuilder<Method>::Build() {
+  return PathMatcherPtr<Method>(new PathMatcher<Method>(std::move(*this)));
+}
+
+// This wrapper converts the |http_rule| into a HttpTemplate. Then, inserts the
+// template into the trie.
+template <class Method>
+bool PathMatcherBuilder<Method>::Register(std::string http_method,
+                                          std::string http_template,
+                                          std::string body_field_path,
+                                          Method method) {
+  std::unique_ptr<HttpTemplate> ht(HttpTemplate::Parse(http_template));
+  if (nullptr == ht) {
+    return false;
+  }
+  PathMatcherNode::PathInfo path_info = TransformHttpTemplate(*ht);
+  if (path_info.path_info().size() == 0) {
+    return false;
+  }
+  // Create & initialize a MethodData struct. Then insert its pointer
+  // into the path matcher trie.
+  auto method_data = std::unique_ptr<MethodData>(new MethodData());
+  method_data->method = method;
+  method_data->variables = std::move(ht->Variables());
+  method_data->body_field_path = std::move(body_field_path);
+
+  if (!root_ptr_->InsertPath(path_info, http_method, method_data.get(), true)) {
+    return false;
+  }
+  // Add the method_data to the methods_ vector for cleanup
+  methods_.emplace_back(std::move(method_data));
+  if (!ht->verb().empty()) {
+    custom_verbs_.insert(ht->verb());
+  }
+  return true;
+}
+
+}  // namespace api_spec
+}  // namespace istio
+
+#endif  // API_SPEC_PATH_MATCHER_H_

--- a/api_spec/src/path_matcher.h
+++ b/api_spec/src/path_matcher.h
@@ -466,7 +466,7 @@ bool PathMatcherBuilder<Method>::Register(std::string http_method,
                                           std::string http_template,
                                           std::string body_field_path,
                                           Method method) {
-  std::unique_ptr<HttpTemplate> ht(HttpTemplate::Parse(http_template));
+  std::unique_ptr<HttpTemplate> ht = HttpTemplate::Parse(http_template);
   if (nullptr == ht) {
     return false;
   }

--- a/api_spec/src/path_matcher_node.cc
+++ b/api_spec/src/path_matcher_node.cc
@@ -1,0 +1,244 @@
+/* Copyright 2017 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "path_matcher_node.h"
+#include "http_template.h"
+
+namespace istio {
+namespace api_spec {
+
+const char HttpMethod_WILD_CARD[] = "*";
+
+namespace {
+
+// Tries to insert the given key-value pair into the collection. Returns nullptr
+// if the insert succeeds. Otherwise, returns a pointer to the existing value.
+//
+// This complements UpdateReturnCopy in that it allows to update only after
+// verifying the old value and still insert quickly without having to look up
+// twice. Unlike UpdateReturnCopy this also does not come with the issue of an
+// undefined previous* in case new data was inserted.
+template <class Collection>
+typename Collection::value_type::second_type* InsertOrReturnExisting(
+    Collection* const collection, const typename Collection::value_type& vt) {
+  std::pair<typename Collection::iterator, bool> ret = collection->insert(vt);
+  if (ret.second) {
+    return nullptr;  // Inserted, no existing previous value.
+  } else {
+    return &ret.first->second;  // Return address of already existing value.
+  }
+}
+
+// Same as above, except for explicit key and data.
+template <class Collection>
+typename Collection::value_type::second_type* InsertOrReturnExisting(
+    Collection* const collection,
+    const typename Collection::value_type::first_type& key,
+    const typename Collection::value_type::second_type& data) {
+  return InsertOrReturnExisting(collection,
+                                typename Collection::value_type(key, data));
+}
+
+// Returns a reference to the pointer associated with key. If not found,
+// a pointee is constructed and added to the map. In that case, the new
+// pointee is value-initialized (aka "default-constructed").
+// Useful for containers of the form Map<Key, Ptr>, where Ptr is pointer-like.
+template <class Collection>
+typename Collection::value_type::second_type& LookupOrInsertNew(
+    Collection* const collection,
+    const typename Collection::value_type::first_type& key) {
+  typedef typename Collection::value_type::second_type Mapped;
+  typedef typename Mapped::element_type Element;
+  std::pair<typename Collection::iterator, bool> ret =
+      collection->insert(typename Collection::value_type(key, Mapped()));
+  if (ret.second) {
+    ret.first->second = Mapped(new Element());
+  }
+  return ret.first->second;
+}
+
+// A convinent function to lookup a STL colllection with two keys.
+// Lookup key1 first, if not found, lookup key2, or return nullptr.
+template <class Collection>
+const typename Collection::value_type::second_type* Find2KeysOrNull(
+    const Collection& collection,
+    const typename Collection::value_type::first_type& key1,
+    const typename Collection::value_type::first_type& key2) {
+  auto it = collection.find(key1);
+  if (it == collection.end()) {
+    it = collection.find(key2);
+    if (it == collection.end()) {
+      return nullptr;
+    }
+  }
+  return &it->second;
+}
+}  // namespace
+
+PathMatcherNode::PathInfo::Builder&
+PathMatcherNode::PathInfo::Builder::AppendLiteralNode(std::string name) {
+  if (name == HttpTemplate::kSingleParameterKey) {
+    //    status_.Update(util::Status(util::error::INVALID_ARGUMENT,
+    //                          StrCat(name, " is a reserved node name.")));
+  }
+  path_.emplace_back(name);
+  return *this;
+}
+
+PathMatcherNode::PathInfo::Builder&
+PathMatcherNode::PathInfo::Builder::AppendSingleParameterNode() {
+  path_.emplace_back(HttpTemplate::kSingleParameterKey);
+  return *this;
+}
+
+PathMatcherNode::PathInfo PathMatcherNode::PathInfo::Builder::Build() const {
+  return PathMatcherNode::PathInfo(*this);
+}
+
+PathMatcherNode::~PathMatcherNode() {}
+
+std::unique_ptr<PathMatcherNode> PathMatcherNode::Clone() const {
+  std::unique_ptr<PathMatcherNode> clone(new PathMatcherNode());
+  clone->result_map_ = result_map_;
+  // deep-copy literal children
+  for (const auto& entry : children_) {
+    clone->children_.emplace(entry.first, entry.second->Clone());
+  }
+  clone->wildcard_ = wildcard_;
+  return clone;
+}
+
+// This recursive function performs an exhaustive DFS of the node's subtrie.
+// The node attempts to find a match for the current part of the path among its
+// children. Children are considered in sequence according to Google HTTP
+// Template Spec matching precedence. If a match is found, the method recurses
+// on the matching child with the next part in path.
+//
+// NB: If this path segment is of repeated-variable type and no matching child
+// is found, the receiver recurses on itself with the next path part.
+//
+// Base Case: |current| is beyond the range of the path parts
+// ==========
+// The receiver node matched the final part in |path|. If a WrapperGraph exists
+// for the given HTTP method, the method copies to the node's WrapperGraph to
+// result and returns true.
+void PathMatcherNode::LookupPath(const RequestPathParts::const_iterator current,
+                                 const RequestPathParts::const_iterator end,
+                                 HttpMethod http_method,
+                                 PathMatcherLookupResult* result) const {
+  // base case
+  if (current == end) {
+    if (!GetResultForHttpMethod(http_method, result)) {
+      // If we didn't find a wrapper graph at this node, check if we have one
+      // in a wildcard (**) child. If we do, use it. This will ensure we match
+      // the root with wildcard templates.
+      auto pair = children_.find(HttpTemplate::kWildCardPathKey);
+      if (pair != children_.end()) {
+        const auto& child = pair->second;
+        child->GetResultForHttpMethod(http_method, result);
+      }
+    }
+    return;
+  }
+  if (LookupPathFromChild(*current, current, end, http_method, result)) {
+    return;
+  }
+  // For wild card node, keeps searching for next path segment until either
+  // 1) reaching the end (/foo/** case), or 2) all remaining segments match
+  // one of child branches (/foo/**/bar/xyz case).
+  if (wildcard_) {
+    LookupPath(current + 1, end, http_method, result);
+    // Since only constant segments are allowed after wild card, no need to
+    // search another wild card nodes from children, so bail out here.
+    return;
+  }
+
+  for (const std::string& child_key :
+       {HttpTemplate::kSingleParameterKey, HttpTemplate::kWildCardPathPartKey,
+        HttpTemplate::kWildCardPathKey}) {
+    if (LookupPathFromChild(child_key, current, end, http_method, result)) {
+      return;
+    }
+  }
+  return;
+}
+
+bool PathMatcherNode::InsertPath(const PathInfo& node_path_info,
+                                 std::string http_method, void* method_data,
+                                 bool mark_duplicates) {
+  return InsertTemplate(node_path_info.path_info().begin(),
+                        node_path_info.path_info().end(), http_method,
+                        method_data, mark_duplicates);
+}
+
+// This method locates a matching child for the |current| path part, inserting a
+// child if not present. Then, the method recurses on this matching child with
+// the next template path part.
+//
+// Base Case: |current| is beyond the range of the path parts
+// ==========
+// This node matched the final part in the iterator of parts. This method
+// updates the node's WrapperGraph for the specified HTTP method.
+bool PathMatcherNode::InsertTemplate(
+    const std::vector<std::string>::const_iterator current,
+    const std::vector<std::string>::const_iterator end, HttpMethod http_method,
+    void* method_data, bool mark_duplicates) {
+  if (current == end) {
+    PathMatcherLookupResult* const existing = InsertOrReturnExisting(
+        &result_map_, http_method, PathMatcherLookupResult(method_data, false));
+    if (existing != nullptr) {
+      if (mark_duplicates) {
+        existing->is_multiple = true;
+      }
+      return false;
+    }
+    return true;
+  }
+  std::unique_ptr<PathMatcherNode>& child =
+      LookupOrInsertNew(&children_, *current);
+  if (*current == HttpTemplate::kWildCardPathKey) {
+    child->set_wildcard(true);
+  }
+  return child->InsertTemplate(current + 1, end, http_method, method_data,
+                               mark_duplicates);
+}
+
+bool PathMatcherNode::LookupPathFromChild(
+    const std::string child_key, const RequestPathParts::const_iterator current,
+    const RequestPathParts::const_iterator end, HttpMethod http_method,
+    PathMatcherLookupResult* result) const {
+  auto pair = children_.find(child_key);
+  if (pair != children_.end()) {
+    pair->second->LookupPath(current + 1, end, http_method, result);
+    if (result != nullptr && result->data != nullptr) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool PathMatcherNode::GetResultForHttpMethod(
+    HttpMethod key, PathMatcherLookupResult* result) const {
+  const PathMatcherLookupResult* found_p =
+      Find2KeysOrNull(result_map_, key, HttpMethod_WILD_CARD);
+  if (found_p != nullptr) {
+    *result = *found_p;
+    return true;
+  }
+  return false;
+}
+
+}  // namespace api_spec
+}  // namespace istio

--- a/api_spec/src/path_matcher_node.h
+++ b/api_spec/src/path_matcher_node.h
@@ -1,0 +1,194 @@
+/* Copyright 2017 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef API_SPEC_PATH_MATCHER_NODE_H_
+#define API_SPEC_PATH_MATCHER_NODE_H_
+
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace istio {
+namespace api_spec {
+
+typedef std::string HttpMethod;
+
+struct PathMatcherLookupResult {
+  PathMatcherLookupResult() : data(nullptr), is_multiple(false) {}
+
+  PathMatcherLookupResult(void* data, bool is_multiple)
+      : data(data), is_multiple(is_multiple) {}
+
+  // The WrapperGraph that is registered to a method (or HTTP path).
+  void* data;
+  // Whether the method (or path) has been registered for more than once.
+  bool is_multiple;
+};
+
+// PathMatcherNodes represents a path part in a PathMatcher trie. Children nodes
+// represent adjacent path parts. A node can have many literal children, one
+// single-parameter child, and one repeated-parameter child.
+//
+// Thread Compatible.
+class PathMatcherNode {
+ public:
+  // Provides information for inserting templates into the trie. Clients can
+  // instantiate PathInfo with the provided Builder.
+  class PathInfo {
+   public:
+    class Builder {
+     public:
+      friend class PathInfo;
+      Builder() : path_() {}
+      ~Builder() {}
+
+      PathMatcherNode::PathInfo Build() const;
+
+      // Appends a node that must match the string value of a request part. The
+      // strings "/." and "/.." are disallowed.
+      //
+      // Example:
+      //
+      // builder.AppendLiteralNode("a")
+      //        .AppendLiteralNode("b")
+      //        .AppendLiteralNode("c");
+      //
+      // Matches the request path: a/b/c
+      Builder& AppendLiteralNode(std::string name);
+
+      // Appends a node that ignores the string value and matches any single
+      // request part.
+      //
+      // Example:
+      //
+      // builder.AppendLiteralNode("a")
+      //        .AppendSingleParameterNode()
+      //        .AppendLiteralNode("c");
+      //
+      // Matching request paths: a/foo/c, a/bar/c, a/1/c
+      Builder& AppendSingleParameterNode();
+
+      // TODO: Appends a node that ignores string values and matches any
+      // number of consecutive request parts.
+      //
+      // Example:
+      //
+      // builder.AppendLiteralNode("a")
+      //        .AppendLiteralNode("b")
+      //        .AppendRepeatedParameterNode();
+      //
+      // Matching request paths: a/b/1/2/3/4/5, a/b/c
+      // Builder& AppendRepeatedParameterNode();
+
+     private:
+      std::vector<std::string> path_;
+    };  // class Builder
+
+    ~PathInfo() {}
+
+    // Returns path information used to insert a new path into a PathMatcherNode
+    // trie.
+    const std::vector<std::string>& path_info() const { return path_; }
+
+   private:
+    explicit PathInfo(const Builder& builder) : path_(builder.path_) {}
+    std::vector<std::string> path_;
+  };  // class PathInfo
+
+  typedef std::vector<std::string> RequestPathParts;
+
+  // Creates a Root node with an empty WrapperGraph map.
+  PathMatcherNode() : result_map_(), children_(), wildcard_(false) {}
+
+  ~PathMatcherNode();
+
+  // Creates a clone of this node and its subtrie
+  std::unique_ptr<PathMatcherNode> Clone() const;
+
+  // Searches subtrie by finding a matching child for the current path part. If
+  // a matching child exists, this function recurses on current + 1 with that
+  // child as the receiver. If a matching descendant is found for the last part
+  // in then this method copies the matching descendant's WrapperGraph,
+  // VariableBindingInfoMap to the result pointers.
+  void LookupPath(const RequestPathParts::const_iterator current,
+                  const RequestPathParts::const_iterator end,
+                  HttpMethod http_method,
+                  PathMatcherLookupResult* result) const;
+
+  // This method inserts a path of nodes into this subtrie. The WrapperGraph,
+  // VariableBindingInfoMap are inserted at the terminal descendant node.
+  // Returns true if the template didn't previously exist. Returns false
+  // otherwise and depends on if mark_duplicates is true, the template will be
+  // marked as having been registered for more than once and the lookup of the
+  // template will yield a special error reporting WrapperGraph.
+  bool InsertPath(const PathInfo& node_path_info, std::string http_method,
+                  void* method_data, bool mark_duplicates);
+
+  void set_wildcard(bool wildcard) { wildcard_ = wildcard; }
+
+ private:
+  // This method inserts a path of nodes into this subtrie (described by the
+  // vector<Info>, starting from the |current| position in the iterator of path
+  // parts, and if necessary, creating intermediate nodes along the way. The
+  // WrapperGraph, VariableBindingInfoMap are inserted at the terminal
+  // descendant node (which corresponds to the string part in the iterator).
+  // Returns true if the template didn't previously exist. Returns false
+  // otherwise and depends on if mark_duplicates is true, the template will be
+  // marked as having been registered for more than once and the lookup of the
+  // template will yield a special error reporting WrapperGraph.
+  bool InsertTemplate(const std::vector<std::string>::const_iterator current,
+                      const std::vector<std::string>::const_iterator end,
+                      HttpMethod http_method, void* method_data,
+                      bool mark_duplicates);
+
+  // Helper method for LookupPath. If the given child key exists, search
+  // continues on the child node pointed by the child key with the next part
+  // in the path. Returns true if found a match for the path eventually.
+  bool LookupPathFromChild(const std::string child_key,
+                           const RequestPathParts::const_iterator current,
+                           const RequestPathParts::const_iterator end,
+                           HttpMethod http_method,
+                           PathMatcherLookupResult* result) const;
+
+  // If a WrapperGraph is found for the provided key, then this method returns
+  // true and copies the WrapperGraph to the provided result pointer. If no
+  // match is found, this method returns false and leaves the result unmodified.
+  //
+  // NB: If result == nullptr, method will return bool value without modifying
+  // result.
+  bool GetResultForHttpMethod(HttpMethod key,
+                              PathMatcherLookupResult* result) const;
+
+  std::map<HttpMethod, PathMatcherLookupResult> result_map_;
+
+  // Lookup must be FAST
+  //
+  // n: the number of paths registered per client varies, but we can expect the
+  // size of |children_| to range from ~5 to ~100 entries.
+  //
+  // To ensure fast lookups when n grows large, it is prudent to consider an
+  // alternative to binary search on a sorted vector.
+  std::unordered_map<std::string, std::unique_ptr<PathMatcherNode>> children_;
+
+  // True if this node represents a wildcard path '**'.
+  bool wildcard_;
+};
+
+}  // namespace api_spec
+}  // namespace istio
+
+#endif  // API_SPEC_PATH_MATCHER_NODE_H_

--- a/api_spec/src/path_matcher_test.cc
+++ b/api_spec/src/path_matcher_test.cc
@@ -1,0 +1,788 @@
+/* Copyright 2017 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "path_matcher.h"
+
+#include <memory>
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using ::testing::ReturnRef;
+
+namespace istio {
+namespace api_spec {
+
+namespace {
+
+// VariableBinding specifies a value for a single field in the request message.
+// When transcoding HTTP/REST/JSON to gRPC/proto the request message is
+// constructed using the HTTP body and the variable bindings (specified through
+// request url).
+struct Binding {
+  // The location of the field in the protobuf message, where the value
+  // needs to be inserted, e.g. "shelf.theme" would mean the "theme" field
+  // of the nested "shelf" message of the request protobuf message.
+  std::vector<std::string> field_path;
+  // The value to be inserted.
+  std::string value;
+};
+
+typedef std::vector<Binding> Bindings;
+typedef std::vector<std::string> FieldPath;
+class MethodInfo {
+ public:
+  MOCK_CONST_METHOD0(system_query_parameter_names,
+                     const std::set<std::string>&());
+};
+
+bool operator==(const Binding& b1, const Binding& b2) {
+  return b1.field_path == b2.field_path && b1.value == b2.value;
+}
+
+std::string FieldPathToString(const FieldPath& fp) {
+  std::string s;
+  for (const auto& f : fp) {
+    if (!s.empty()) {
+      s += ".";
+    }
+    s += f;
+  }
+  return s;
+}
+
+}  // namespace
+
+std::ostream& operator<<(std::ostream& os, const Binding& b) {
+  return os << "{ " << FieldPathToString(b.field_path) << "=" << b.value << "}";
+}
+
+std::ostream& operator<<(std::ostream& os, const Bindings& bindings) {
+  for (const auto& b : bindings) {
+    os << b << std::endl;
+  }
+  return os;
+}
+
+namespace {
+
+class PathMatcherTest : public ::testing::Test {
+ protected:
+  PathMatcherTest() {}
+  ~PathMatcherTest() {}
+
+  MethodInfo* AddPathWithBodyFieldPath(std::string http_method,
+                                       std::string http_template,
+                                       std::string body_field_path) {
+    auto method = new MethodInfo();
+    ON_CALL(*method, system_query_parameter_names())
+        .WillByDefault(ReturnRef(empty_set_));
+    if (!builder_.Register(http_method, http_template, body_field_path,
+                           method)) {
+      delete method;
+      return nullptr;
+    }
+    stored_methods_.emplace_back(method);
+    return method;
+  }
+
+  MethodInfo* AddPathWithSystemParams(
+      std::string http_method, std::string http_template,
+      const std::set<std::string>* system_params) {
+    auto method = new MethodInfo();
+    ON_CALL(*method, system_query_parameter_names())
+        .WillByDefault(ReturnRef(*system_params));
+    if (!builder_.Register(http_method, http_template, std::string(), method)) {
+      delete method;
+      return nullptr;
+    }
+    stored_methods_.emplace_back(method);
+    return method;
+  }
+
+  MethodInfo* AddPath(std::string http_method, std::string http_template) {
+    return AddPathWithBodyFieldPath(http_method, http_template, std::string());
+  }
+
+  MethodInfo* AddGetPath(std::string path) { return AddPath("GET", path); }
+
+  void Build() { matcher_ = builder_.Build(); }
+
+  MethodInfo* LookupWithBodyFieldPath(std::string method, std::string path,
+                                      Bindings* bindings,
+                                      std::string* body_field_path) {
+    return matcher_->Lookup(method, path, "", bindings, body_field_path);
+  }
+
+  MethodInfo* Lookup(std::string method, std::string path, Bindings* bindings) {
+    std::string body_field_path;
+    return matcher_->Lookup(method, path, std::string(), bindings,
+                            &body_field_path);
+  }
+
+  MethodInfo* LookupWithParams(std::string method, std::string path,
+                               std::string query_params, Bindings* bindings) {
+    std::string body_field_path;
+    return matcher_->Lookup(method, path, query_params, bindings,
+                            &body_field_path);
+  }
+
+  MethodInfo* LookupNoBindings(std::string method, std::string path) {
+    Bindings bindings;
+    std::string body_field_path;
+    auto result = matcher_->Lookup(method, path, std::string(), &bindings,
+                                   &body_field_path);
+    EXPECT_EQ(0, bindings.size());
+    return result;
+  }
+
+ private:
+  PathMatcherBuilder<MethodInfo*> builder_;
+  PathMatcherPtr<MethodInfo*> matcher_;
+  std::vector<std::unique_ptr<MethodInfo>> stored_methods_;
+  std::set<std::string> empty_set_;
+};
+
+TEST_F(PathMatcherTest, WildCardMatchesRoot) {
+  MethodInfo* data = AddGetPath("/**");
+  Build();
+
+  EXPECT_NE(nullptr, data);
+
+  EXPECT_EQ(LookupNoBindings("GET", "/"), data);
+  EXPECT_EQ(LookupNoBindings("GET", "/a"), data);
+  EXPECT_EQ(LookupNoBindings("GET", "/a/"), data);
+}
+
+TEST_F(PathMatcherTest, WildCardMatches) {
+  // '*' only matches one path segment, but '**' matches the remaining path.
+  MethodInfo* a__ = AddGetPath("/a/**");
+  MethodInfo* b_ = AddGetPath("/b/*");
+  MethodInfo* c_d__ = AddGetPath("/c/*/d/**");
+  MethodInfo* c_de = AddGetPath("/c/*/d/e");
+  MethodInfo* cfde = AddGetPath("/c/f/d/e");
+  Build();
+
+  EXPECT_NE(nullptr, a__);
+  EXPECT_NE(nullptr, b_);
+  EXPECT_NE(nullptr, c_d__);
+  EXPECT_NE(nullptr, c_de);
+  EXPECT_NE(nullptr, cfde);
+
+  EXPECT_EQ(LookupNoBindings("GET", "/a/b"), a__);
+  EXPECT_EQ(LookupNoBindings("GET", "/a/b/c"), a__);
+  EXPECT_EQ(LookupNoBindings("GET", "/b/c"), b_);
+
+  EXPECT_EQ(LookupNoBindings("GET", "b/c/d"), nullptr);
+  EXPECT_EQ(LookupNoBindings("GET", "/c/u/d/v"), c_d__);
+  EXPECT_EQ(LookupNoBindings("GET", "/c/v/d/w/x"), c_d__);
+  EXPECT_EQ(LookupNoBindings("GET", "/c/x/y/d/z"), nullptr);
+  EXPECT_EQ(LookupNoBindings("GET", "/c//v/d/w/x"), nullptr);
+
+  // Test that more specific match overrides wildcard "**"" match.
+  EXPECT_EQ(LookupNoBindings("GET", "/c/x/d/e"), c_de);
+  // Test that more specific match overrides wildcard "*"" match.
+  EXPECT_EQ(LookupNoBindings("GET", "/c/f/d/e"), cfde);
+}
+
+TEST_F(PathMatcherTest, WildCardMethodMatches) {
+  MethodInfo* a__ = AddPath("*", "/a/**");
+  MethodInfo* b_ = AddPath("*", "/b/*");
+  Build();
+
+  EXPECT_NE(nullptr, a__);
+  EXPECT_NE(nullptr, b_);
+
+  std::vector<std::string> all_methods{"GET", "POST", "DELETE", "PATCH", "PUT"};
+  for (const auto& method : all_methods) {
+    EXPECT_EQ(LookupNoBindings(method, "/a/b"), a__);
+    EXPECT_EQ(LookupNoBindings(method, "/a/b/c"), a__);
+    EXPECT_EQ(LookupNoBindings(method, "/b/c"), b_);
+  }
+}
+
+TEST_F(PathMatcherTest, VariableBindings) {
+  MethodInfo* a_cde = AddGetPath("/a/{x}/c/d/e");
+  MethodInfo* a_b_c = AddGetPath("/{x=a/*}/b/{y=*}/c");
+  MethodInfo* ab_d__ = AddGetPath("/a/{x=b/*}/{y=d/**}");
+  MethodInfo* alpha_beta__gamma = AddGetPath("/alpha/{x=*}/beta/{y=**}/gamma");
+  MethodInfo* _a = AddGetPath("/{x=*}/a");
+  MethodInfo* __ab = AddGetPath("/{x=**}/a/b");
+  MethodInfo* ab_ = AddGetPath("/a/b/{x=*}");
+  MethodInfo* abc__ = AddGetPath("/a/b/c/{x=**}");
+  MethodInfo* _def__ = AddGetPath("/{x=*}/d/e/f/{y=**}");
+  Build();
+
+  EXPECT_NE(nullptr, a_cde);
+  EXPECT_NE(nullptr, a_b_c);
+  EXPECT_NE(nullptr, ab_d__);
+  EXPECT_NE(nullptr, alpha_beta__gamma);
+  EXPECT_NE(nullptr, _a);
+  EXPECT_NE(nullptr, __ab);
+  EXPECT_NE(nullptr, ab_);
+  EXPECT_NE(nullptr, abc__);
+  EXPECT_NE(nullptr, _def__);
+
+  Bindings bindings;
+  EXPECT_EQ(Lookup("GET", "/a/book/c/d/e", &bindings), a_cde);
+  EXPECT_EQ(Bindings({
+                Binding{FieldPath{"x"}, "book"},
+            }),
+            bindings);
+
+  EXPECT_EQ(Lookup("GET", "/a/hello/b/world/c", &bindings), a_b_c);
+  EXPECT_EQ(
+      Bindings({
+          Binding{FieldPath{"x"}, "a/hello"}, Binding{FieldPath{"y"}, "world"},
+      }),
+      bindings);
+
+  EXPECT_EQ(Lookup("GET", "/a/b/zoo/d/animal/tiger", &bindings), ab_d__);
+  EXPECT_EQ(Bindings({
+                Binding{FieldPath{"x"}, "b/zoo"},
+                Binding{FieldPath{"y"}, "d/animal/tiger"},
+            }),
+            bindings);
+
+  EXPECT_EQ(Lookup("GET", "/alpha/dog/beta/eat/bones/gamma", &bindings),
+            alpha_beta__gamma);
+  EXPECT_EQ(
+      Bindings({
+          Binding{FieldPath{"x"}, "dog"}, Binding{FieldPath{"y"}, "eat/bones"},
+      }),
+      bindings);
+
+  EXPECT_EQ(Lookup("GET", "/foo/a", &bindings), _a);
+  EXPECT_EQ(Bindings({
+                Binding{FieldPath{"x"}, "foo"},
+            }),
+            bindings);
+
+  EXPECT_EQ(Lookup("GET", "/foo/bar/a/b", &bindings), __ab);
+  EXPECT_EQ(Bindings({
+                Binding{FieldPath{"x"}, "foo/bar"},
+            }),
+            bindings);
+
+  EXPECT_EQ(Lookup("GET", "/a/b/foo", &bindings), ab_);
+  EXPECT_EQ(Bindings({
+                Binding{FieldPath{"x"}, "foo"},
+            }),
+            bindings);
+
+  EXPECT_EQ(Lookup("GET", "/a/b/c/foo/bar/baz", &bindings), abc__);
+  EXPECT_EQ(Bindings({
+                Binding{FieldPath{"x"}, "foo/bar/baz"},
+            }),
+            bindings);
+
+  EXPECT_EQ(Lookup("GET", "/foo/d/e/f/bar/baz", &bindings), _def__);
+  EXPECT_EQ(
+      Bindings({
+          Binding{FieldPath{"x"}, "foo"}, Binding{FieldPath{"y"}, "bar/baz"},
+      }),
+      bindings);
+}
+
+TEST_F(PathMatcherTest, PercentEscapesUnescapedForSingleSegment) {
+  MethodInfo* a_c = AddGetPath("/a/{x}/c");
+  Build();
+
+  EXPECT_NE(nullptr, a_c);
+
+  Bindings bindings;
+  EXPECT_EQ(Lookup("GET", "/a/p%20q%2Fr/c", &bindings), a_c);
+  EXPECT_EQ(Bindings({
+                Binding{FieldPath{"x"}, "p q/r"},
+            }),
+            bindings);
+}
+
+namespace {
+
+char HexDigit(unsigned char digit, bool uppercase) {
+  if (digit < 10) {
+    return '0' + digit;
+  } else if (uppercase) {
+    return 'A' + digit - 10;
+  } else {
+    return 'a' + digit - 10;
+  }
+}
+
+}  // namespace {
+
+TEST_F(PathMatcherTest, PercentEscapesUnescapedForSingleSegmentAllAsciiChars) {
+  MethodInfo* a_c = AddGetPath("/{x}");
+  Build();
+
+  EXPECT_NE(nullptr, a_c);
+
+  for (int u = 0; u < 2; ++u) {
+    for (char c = 0; c < 0x7f; ++c) {
+      std::string path("/%");
+      path += HexDigit((c & 0xf0) >> 4, 0 != u);
+      path += HexDigit(c & 0x0f, 0 != u);
+
+      Bindings bindings;
+      EXPECT_EQ(Lookup("GET", path, &bindings), a_c);
+      EXPECT_EQ(Bindings({
+                    Binding{FieldPath{"x"}, std::string(1, (char)c)},
+                }),
+                bindings);
+    }
+  }
+}
+
+TEST_F(PathMatcherTest, PercentEscapesNotUnescapedForMultiSegment1) {
+  MethodInfo* ap_q_c = AddGetPath("/a/{x=p/*/q/*}/c");
+  Build();
+
+  EXPECT_NE(nullptr, ap_q_c);
+
+  Bindings bindings;
+  EXPECT_EQ(Lookup("GET", "/a/p/foo%20foo/q/bar%2Fbar/c", &bindings), ap_q_c);
+  // space (%20) is escaped, but slash (%2F) isn't.
+  EXPECT_EQ(Bindings({Binding{FieldPath{"x"}, "p/foo foo/q/bar%2Fbar"}}),
+            bindings);
+}
+
+TEST_F(PathMatcherTest, PercentEscapesNotUnescapedForMultiSegment2) {
+  MethodInfo* a__c = AddGetPath("/a/{x=**}/c");
+  Build();
+
+  EXPECT_NE(nullptr, a__c);
+
+  Bindings bindings;
+  EXPECT_EQ(Lookup("GET", "/a/p/foo%20foo/q/bar%2Fbar/c", &bindings), a__c);
+  // space (%20) is escaped, but slash (%2F) isn't.
+  EXPECT_EQ(Bindings({Binding{FieldPath{"x"}, "p/foo foo/q/bar%2Fbar"}}),
+            bindings);
+}
+
+TEST_F(PathMatcherTest, OnlyUnreservedCharsAreUnescapedForMultiSegmentMatch) {
+  MethodInfo* a__c = AddGetPath("/a/{x=**}/c");
+  Build();
+
+  EXPECT_NE(nullptr, a__c);
+
+  Bindings bindings;
+  EXPECT_EQ(
+      Lookup("GET",
+             "/a/%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D/c",
+             &bindings),
+      a__c);
+
+  // All %XX are reserved characters, they should be intact.
+  EXPECT_EQ(Bindings({Binding{
+                FieldPath{"x"},
+                "%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D"}}),
+            bindings);
+}
+
+TEST_F(PathMatcherTest, VariableBindingsWithCustomVerb) {
+  MethodInfo* a_verb = AddGetPath("/a/{y=*}:verb");
+  MethodInfo* ad__verb = AddGetPath("/a/{y=d/**}:verb");
+  MethodInfo* _averb = AddGetPath("/{x=*}/a:verb");
+  MethodInfo* __bverb = AddGetPath("/{x=**}/b:verb");
+  MethodInfo* e_fverb = AddGetPath("/e/{x=*}/f:verb");
+  MethodInfo* g__hverb = AddGetPath("/g/{x=**}/h:verb");
+  Build();
+
+  EXPECT_NE(nullptr, a_verb);
+  EXPECT_NE(nullptr, ad__verb);
+  EXPECT_NE(nullptr, _averb);
+  EXPECT_NE(nullptr, __bverb);
+  EXPECT_NE(nullptr, e_fverb);
+  EXPECT_NE(nullptr, g__hverb);
+
+  Bindings bindings;
+  EXPECT_EQ(Lookup("GET", "/a/world:verb", &bindings), a_verb);
+  EXPECT_EQ(Bindings({Binding{FieldPath{"y"}, "world"}}), bindings);
+
+  EXPECT_EQ(Lookup("GET", "/a/d/animal/tiger:verb", &bindings), ad__verb);
+  EXPECT_EQ(Bindings({Binding{FieldPath{"y"}, "d/animal/tiger"}}), bindings);
+
+  EXPECT_EQ(Lookup("GET", "/foo/a:verb", &bindings), _averb);
+  EXPECT_EQ(Bindings({Binding{FieldPath{"x"}, "foo"}}), bindings);
+
+  EXPECT_EQ(Lookup("GET", "/foo/bar/baz/b:verb", &bindings), __bverb);
+  EXPECT_EQ(Bindings({Binding{FieldPath{"x"}, "foo/bar/baz"}}), bindings);
+
+  EXPECT_EQ(Lookup("GET", "/e/foo/f:verb", &bindings), e_fverb);
+  EXPECT_EQ(Bindings({Binding{FieldPath{"x"}, "foo"}}), bindings);
+
+  EXPECT_EQ(Lookup("GET", "/g/foo/bar/h:verb", &bindings), g__hverb);
+  EXPECT_EQ(Bindings({Binding{FieldPath{"x"}, "foo/bar"}}), bindings);
+}
+
+TEST_F(PathMatcherTest, ConstantSuffixesWithVariable) {
+  MethodInfo* ab__ = AddGetPath("/a/{x=b/**}");
+  MethodInfo* ab__z = AddGetPath("/a/{x=b/**}/z");
+  MethodInfo* ab__yz = AddGetPath("/a/{x=b/**}/y/z");
+  MethodInfo* ab__verb = AddGetPath("/a/{x=b/**}:verb");
+  MethodInfo* a__ = AddGetPath("/a/{x=**}");
+  MethodInfo* c_d__e = AddGetPath("/c/{x=*}/{y=d/**}/e");
+  MethodInfo* c_d__everb = AddGetPath("/c/{x=*}/{y=d/**}/e:verb");
+  MethodInfo* f___g = AddGetPath("/f/{x=*}/{y=**}/g");
+  MethodInfo* f___gverb = AddGetPath("/f/{x=*}/{y=**}/g:verb");
+  MethodInfo* ab_yz__foo = AddGetPath("/a/{x=b/*/y/z/**}/foo");
+  MethodInfo* ab___yzfoo = AddGetPath("/a/{x=b/*/**/y/z}/foo");
+  Build();
+
+  EXPECT_NE(nullptr, ab__);
+  EXPECT_NE(nullptr, ab__z);
+  EXPECT_NE(nullptr, ab__yz);
+  EXPECT_NE(nullptr, ab__verb);
+  EXPECT_NE(nullptr, c_d__e);
+  EXPECT_NE(nullptr, c_d__everb);
+  EXPECT_NE(nullptr, f___g);
+  EXPECT_NE(nullptr, f___gverb);
+  EXPECT_NE(nullptr, ab_yz__foo);
+  EXPECT_NE(nullptr, ab___yzfoo);
+
+  Bindings bindings;
+
+  EXPECT_EQ(Lookup("GET", "/a/b/hello/world/c", &bindings), ab__);
+  EXPECT_EQ(Bindings({Binding{FieldPath{"x"}, "b/hello/world/c"}}), bindings);
+
+  EXPECT_EQ(Lookup("GET", "/a/b/world/c/z", &bindings), ab__z);
+  EXPECT_EQ(Bindings({Binding{FieldPath{"x"}, "b/world/c"}}), bindings);
+
+  EXPECT_EQ(Lookup("GET", "/a/b/world/c/y/z", &bindings), ab__yz);
+  EXPECT_EQ(Bindings({Binding{FieldPath{"x"}, "b/world/c"}}), bindings);
+
+  EXPECT_EQ(Lookup("GET", "/a/b/world/c:verb", &bindings), ab__verb);
+  EXPECT_EQ(Bindings({Binding{FieldPath{"x"}, "b/world/c"}}), bindings);
+
+  EXPECT_EQ(Lookup("GET", "/a/hello/b/world/c", &bindings), a__);
+  EXPECT_EQ(Bindings({Binding{FieldPath{"x"}, "hello/b/world/c"}}), bindings);
+
+  EXPECT_EQ(Lookup("GET", "/c/hello/d/esp/world/e", &bindings), c_d__e);
+  EXPECT_EQ(Bindings({Binding{FieldPath{"x"}, "hello"},
+                      Binding{FieldPath{"y"}, "d/esp/world"}}),
+            bindings);
+
+  EXPECT_EQ(Lookup("GET", "/c/hola/d/esp/mundo/e:verb", &bindings), c_d__everb);
+  EXPECT_EQ(Bindings({Binding{FieldPath{"x"}, "hola"},
+                      Binding{FieldPath{"y"}, "d/esp/mundo"}}),
+            bindings);
+
+  EXPECT_EQ(Lookup("GET", "/f/foo/bar/baz/g", &bindings), f___g);
+  EXPECT_EQ(Bindings({Binding{FieldPath{"x"}, "foo"},
+                      Binding{FieldPath{"y"}, "bar/baz"}}),
+            bindings);
+
+  EXPECT_EQ(Lookup("GET", "/f/foo/bar/baz/g:verb", &bindings), f___gverb);
+  EXPECT_EQ(Bindings({Binding{FieldPath{"x"}, "foo"},
+                      Binding{FieldPath{"y"}, "bar/baz"}}),
+            bindings);
+
+  EXPECT_EQ(Lookup("GET", "/a/b/foo/y/z/bar/baz/foo", &bindings), ab_yz__foo);
+  EXPECT_EQ(Bindings({
+                Binding{FieldPath{"x"}, "b/foo/y/z/bar/baz"},
+            }),
+            bindings);
+
+  EXPECT_EQ(Lookup("GET", "/a/b/foo/bar/baz/y/z/foo", &bindings), ab___yzfoo);
+  EXPECT_EQ(Bindings({
+                Binding{FieldPath{"x"}, "b/foo/bar/baz/y/z"},
+            }),
+            bindings);
+}
+
+TEST_F(PathMatcherTest, InvalidTemplates) {
+  EXPECT_EQ(nullptr, AddGetPath("/a{x=b/**}/{y=*}"));
+  EXPECT_EQ(nullptr, AddGetPath("/a{x=b/**}/bb/{y=*}"));
+  EXPECT_EQ(nullptr, AddGetPath("/a{x=b/**}/{y=**}"));
+  EXPECT_EQ(nullptr, AddGetPath("/a{x=b/**}/bb/{y=**}"));
+
+  EXPECT_EQ(nullptr, AddGetPath("/a/**/*"));
+  EXPECT_EQ(nullptr, AddGetPath("/a/**/foo/*"));
+  EXPECT_EQ(nullptr, AddGetPath("/a/**/**"));
+  EXPECT_EQ(nullptr, AddGetPath("/a/**/foo/**"));
+}
+
+TEST_F(PathMatcherTest, CustomVerbMatches) {
+  MethodInfo* some_const_verb = AddGetPath("/some/const:verb");
+  MethodInfo* some__verb = AddGetPath("/some/*:verb");
+  MethodInfo* some__foo_verb = AddGetPath("/some/*/foo:verb");
+  MethodInfo* other__verb = AddGetPath("/other/**:verb");
+  MethodInfo* other__const_verb = AddGetPath("/other/**/const:verb");
+  Build();
+
+  EXPECT_NE(nullptr, some_const_verb);
+  EXPECT_NE(nullptr, some__verb);
+  EXPECT_NE(nullptr, some__foo_verb);
+  EXPECT_NE(nullptr, other__verb);
+  EXPECT_NE(nullptr, other__const_verb);
+
+  EXPECT_EQ(LookupNoBindings("GET", "/some/const:verb"), some_const_verb);
+  EXPECT_EQ(LookupNoBindings("GET", "/some/other:verb"), some__verb);
+  EXPECT_EQ(LookupNoBindings("GET", "/some/other:verb/"), nullptr);
+  EXPECT_EQ(LookupNoBindings("GET", "/some/bar/foo:verb"), some__foo_verb);
+  EXPECT_EQ(LookupNoBindings("GET", "/some/foo1/foo2/foo:verb"), nullptr);
+  EXPECT_EQ(LookupNoBindings("GET", "/some/foo/bar:verb"), nullptr);
+  EXPECT_EQ(LookupNoBindings("GET", "/other/bar/foo:verb"), other__verb);
+  EXPECT_EQ(LookupNoBindings("GET", "/other/bar/foo/const:verb"),
+            other__const_verb);
+}
+
+TEST_F(PathMatcherTest, CustomVerbMatch2) {
+  MethodInfo* verb = AddGetPath("/*/*:verb");
+  Build();
+  EXPECT_EQ(LookupNoBindings("GET", "/some:verb/const:verb"), verb);
+}
+
+TEST_F(PathMatcherTest, CustomVerbMatch3) {
+  MethodInfo* verb = AddGetPath("/foo/*");
+  Build();
+
+  // This is not custom verb since it was not configured.
+  EXPECT_EQ(LookupNoBindings("GET", "/foo/other:verb"), verb);
+}
+
+TEST_F(PathMatcherTest, CustomVerbMatch4) {
+  MethodInfo* a = AddGetPath("/foo/*/hello");
+  Build();
+
+  EXPECT_NE(nullptr, a);
+
+  // last slash is before last colon.
+  EXPECT_EQ(LookupNoBindings("GET", "/foo/other:verb/hello"), a);
+}
+
+TEST_F(PathMatcherTest, RejectPartialMatches) {
+  MethodInfo* prefix_middle_suffix = AddGetPath("/prefix/middle/suffix");
+  MethodInfo* prefix_middle = AddGetPath("/prefix/middle");
+  MethodInfo* prefix = AddGetPath("/prefix");
+  Build();
+
+  EXPECT_NE(nullptr, prefix_middle_suffix);
+  EXPECT_NE(nullptr, prefix_middle);
+  EXPECT_NE(nullptr, prefix);
+
+  EXPECT_EQ(LookupNoBindings("GET", "/prefix/middle/suffix"),
+            prefix_middle_suffix);
+  EXPECT_EQ(LookupNoBindings("GET", "/prefix/middle"), prefix_middle);
+  EXPECT_EQ(LookupNoBindings("GET", "/prefix"), prefix);
+
+  EXPECT_EQ(LookupNoBindings("GET", "/prefix/middle/suffix/other"), nullptr);
+  EXPECT_EQ(LookupNoBindings("GET", "/prefix/middle/other"), nullptr);
+  EXPECT_EQ(LookupNoBindings("GET", "/prefix/other"), nullptr);
+  EXPECT_EQ(LookupNoBindings("GET", "/other"), nullptr);
+}
+
+TEST_F(PathMatcherTest, LookupReturnsNullIfMatcherEmpty) {
+  Build();
+  EXPECT_EQ(LookupNoBindings("GET", "a/b/blue/foo"), nullptr);
+}
+
+TEST_F(PathMatcherTest, LookupSimplePaths) {
+  MethodInfo* pms = AddGetPath("/prefix/middle/suffix");
+  MethodInfo* pmo = AddGetPath("/prefix/middle/othersuffix");
+  MethodInfo* pos = AddGetPath("/prefix/othermiddle/suffix");
+  MethodInfo* oms = AddGetPath("/otherprefix/middle/suffix");
+  MethodInfo* os = AddGetPath("/otherprefix/suffix");
+  Build();
+
+  EXPECT_NE(nullptr, pms);
+  EXPECT_NE(nullptr, pmo);
+  EXPECT_NE(nullptr, pos);
+  EXPECT_NE(nullptr, oms);
+  EXPECT_NE(nullptr, os);
+
+  EXPECT_EQ(LookupNoBindings("GET", "/prefix/not/a/path"), nullptr);
+  EXPECT_EQ(LookupNoBindings("GET", "/prefix/middle"), nullptr);
+  EXPECT_EQ(LookupNoBindings("GET", "/prefix/not/othermiddle"), nullptr);
+  EXPECT_EQ(LookupNoBindings("GET", "/otherprefix/suffix/othermiddle"),
+            nullptr);
+
+  EXPECT_EQ(LookupNoBindings("GET", "/prefix/middle/suffix"), pms);
+  EXPECT_EQ(LookupNoBindings("GET", "/prefix/middle/othersuffix"), pmo);
+  EXPECT_EQ(LookupNoBindings("GET", "/prefix/othermiddle/suffix"), pos);
+  EXPECT_EQ(LookupNoBindings("GET", "/otherprefix/middle/suffix"), oms);
+  EXPECT_EQ(LookupNoBindings("GET", "/otherprefix/suffix"), os);
+  EXPECT_EQ(LookupNoBindings("GET", "/otherprefix/suffix?foo=bar"), os);
+}
+
+TEST_F(PathMatcherTest, ReplacevoidForPath) {
+  const std::string path = "/foo/bar";
+  auto first_mock_proc = AddGetPath(path);
+  EXPECT_NE(nullptr, first_mock_proc);
+  // Second call should fail
+  EXPECT_EQ(nullptr, AddGetPath(path));
+  Build();
+
+  // Lookup result should get the first one.
+  EXPECT_EQ(LookupNoBindings("GET", path), first_mock_proc);
+}
+
+TEST_F(PathMatcherTest, AllowDuplicate) {
+  MethodInfo* id = AddGetPath("/a/{id}");
+  EXPECT_NE(nullptr, id);
+  // Second call should fail
+  EXPECT_EQ(nullptr, AddGetPath("/a/{name}"));
+  Build();
+
+  Bindings bindings;
+  // Lookup result should get the first one.
+  EXPECT_EQ(Lookup("GET", "/a/x", &bindings), id);
+}
+
+TEST_F(PathMatcherTest, DuplicatedOptions) {
+  MethodInfo* get_id = AddPath("GET", "/a/{id}");
+  MethodInfo* post_name = AddPath("POST", "/a/{name}");
+  MethodInfo* options_id = AddPath("OPTIONS", "/a/{id}");
+  EXPECT_EQ(nullptr, AddPath("OPTIONS", "/a/{name}"));
+  Build();
+
+  Bindings bindings;
+  // Lookup result should get the first one.
+  EXPECT_EQ(Lookup("OPTIONS", "/a/x", &bindings), options_id);
+
+  EXPECT_EQ(Lookup("GET", "/a/x", &bindings), get_id);
+  EXPECT_EQ(Lookup("POST", "/a/x", &bindings), post_name);
+}
+
+// If a path matches a complete branch of trie, but is longer than the branch
+// (ie. the trie cannot match all the way to the end of the path), Lookup
+// should return nullptr.
+TEST_F(PathMatcherTest, LookupReturnsNullForOverspecifiedPath) {
+  EXPECT_NE(nullptr, AddGetPath("/a/b/c"));
+  EXPECT_NE(nullptr, AddGetPath("/a/b"));
+  Build();
+  EXPECT_EQ(LookupNoBindings("GET", "/a/b/c/d"), nullptr);
+}
+
+TEST_F(PathMatcherTest, ReturnNullvoidSharedPtrForUnderspecifiedPath) {
+  EXPECT_NE(nullptr, AddGetPath("/a/b/c/d"));
+  Build();
+  EXPECT_EQ(LookupNoBindings("GET", "/a/b/c"), nullptr);
+}
+
+TEST_F(PathMatcherTest, DifferentHttpMethod) {
+  auto ab = AddGetPath("/a/b");
+  Build();
+  EXPECT_NE(nullptr, ab);
+  EXPECT_EQ(LookupNoBindings("GET", "/a/b"), ab);
+  EXPECT_EQ(LookupNoBindings("POST", "/a/b"), nullptr);
+}
+
+TEST_F(PathMatcherTest, BodyFieldPathTest) {
+  auto a = AddPathWithBodyFieldPath("GET", "/a", "b");
+  auto cd = AddPathWithBodyFieldPath("GET", "/c/d", "e.f.g");
+  Build();
+  EXPECT_NE(nullptr, a);
+  EXPECT_NE(nullptr, cd);
+  std::string body_field_path;
+  EXPECT_EQ(LookupWithBodyFieldPath("GET", "/a", nullptr, &body_field_path), a);
+  EXPECT_EQ("b", body_field_path);
+  EXPECT_EQ(LookupWithBodyFieldPath("GET", "/c/d", nullptr, &body_field_path),
+            cd);
+  EXPECT_EQ("e.f.g", body_field_path);
+}
+
+TEST_F(PathMatcherTest, VariableBindingsWithQueryParams) {
+  MethodInfo* a = AddGetPath("/a");
+  MethodInfo* a_b = AddGetPath("/a/{x}/b");
+  MethodInfo* a_b_c = AddGetPath("/a/{x}/b/{y}/c");
+  Build();
+
+  EXPECT_NE(nullptr, a);
+  EXPECT_NE(nullptr, a_b);
+  EXPECT_NE(nullptr, a_b_c);
+
+  Bindings bindings;
+  EXPECT_EQ(LookupWithParams("GET", "/a", "x=hello", &bindings), a);
+  EXPECT_EQ(Bindings({
+                Binding{FieldPath{"x"}, "hello"},
+            }),
+            bindings);
+
+  EXPECT_EQ(LookupWithParams("GET", "/a/book/b", "y=shelf&z=author", &bindings),
+            a_b);
+  EXPECT_EQ(
+      Bindings({
+          Binding{FieldPath{"x"}, "book"}, Binding{FieldPath{"y"}, "shelf"},
+          Binding{FieldPath{"z"}, "author"},
+      }),
+      bindings);
+
+  EXPECT_EQ(LookupWithParams("GET", "/a/hello/b/endpoints/c",
+                             "z=server&t=proxy", &bindings),
+            a_b_c);
+  EXPECT_EQ(
+      Bindings({
+          Binding{FieldPath{"x"}, "hello"},
+          Binding{FieldPath{"y"}, "endpoints"},
+          Binding{FieldPath{"z"}, "server"}, Binding{FieldPath{"t"}, "proxy"},
+      }),
+      bindings);
+}
+
+TEST_F(PathMatcherTest, VariableBindingsWithQueryParamsEncoding) {
+  MethodInfo* a = AddGetPath("/a");
+  Build();
+
+  EXPECT_NE(nullptr, a);
+
+  Bindings bindings;
+  EXPECT_EQ(LookupWithParams("GET", "/a", "x=Hello%20world", &bindings), a);
+  EXPECT_EQ(Bindings({
+                Binding{FieldPath{"x"}, "Hello world"},
+            }),
+            bindings);
+
+  EXPECT_EQ(LookupWithParams("GET", "/a", "x=%24%25%2F%20%0A", &bindings), a);
+  EXPECT_EQ(Bindings({
+                Binding{FieldPath{"x"}, "$%/ \n"},
+            }),
+            bindings);
+}
+
+TEST_F(PathMatcherTest, VariableBindingsWithQueryParamsAndSystemParams) {
+  std::set<std::string> system_params{"key", "api_key"};
+  MethodInfo* a_b = AddPathWithSystemParams("GET", "/a/{x}/b", &system_params);
+  Build();
+
+  EXPECT_NE(nullptr, a_b);
+
+  Bindings bindings;
+  EXPECT_EQ(LookupWithParams("GET", "/a/hello/b", "y=world&api_key=secret",
+                             &bindings),
+            a_b);
+  EXPECT_EQ(
+      Bindings({
+          Binding{FieldPath{"x"}, "hello"}, Binding{FieldPath{"y"}, "world"},
+      }),
+      bindings);
+  EXPECT_EQ(
+      LookupWithParams("GET", "/a/hello/b", "key=secret&y=world", &bindings),
+      a_b);
+  EXPECT_EQ(
+      Bindings({
+          Binding{FieldPath{"x"}, "hello"}, Binding{FieldPath{"y"}, "world"},
+      }),
+      bindings);
+}
+
+}  // namespace
+
+}  // namespace api_spec
+}  // namespace istio


### PR DESCRIPTION
These code are copied from ESP (https://github.com/cloudendpoints/esp).  It will be used for template match for http api_spec.

Following libraries will be at top level folder:

api_spec/
auth/
mixer_client/
mixer_control/

Such that api_spec and auth libraries can be used by mixer_control.   Or someone can build a simple Envoy filter to call them directly.


