### PR TITLE
Add quota config parser.

### DIFF
--- a/quota/BUILD
+++ b/quota/BUILD
@@ -1,0 +1,55 @@
+# Copyright 2017 Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+licenses(["notice"])
+
+cc_library(
+    name = "requirement_header",
+    hdrs = [
+        "include/requirement.h",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "config_parser_lib",
+    srcs = [
+        "src/config_parser_impl.cc",
+        "src/config_parser_impl.h",
+    ],
+    hdrs = [
+        "include/config_parser.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":requirement_header",
+        "@mixerapi_git//:mixer_client_config_cc_proto",
+    ],
+)
+
+cc_test(
+    name = "config_parser_impl_test",
+    size = "small",
+    srcs = ["src/config_parser_impl_test.cc"],
+    linkopts = [
+        "-lm",
+        "-lpthread",
+    ],
+    linkstatic = 1,
+    deps = [
+        ":config_parser_lib",
+        "//:mixer_client_lib",
+        "//external:googletest_main",
+    ],
+)

--- a/quota/include/config_parser.h
+++ b/quota/include/config_parser.h
@@ -1,0 +1,46 @@
+/* Copyright 2017 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef QUOTA_CONFIG_PARSER_H_
+#define QUOTA_CONFIG_PARSER_H_
+
+#include <memory>
+#include <vector>
+
+#include "mixer/v1/attributes.pb.h"
+#include "mixer/v1/config/client/quota.pb.h"
+#include "requirement.h"
+
+namespace istio {
+namespace quota {
+
+// An object to parse quota config to generate quota requirements.
+class ConfigParser {
+ public:
+  virtual ~ConfigParser() {}
+
+  // Get quota requirements for a attribute set.
+  virtual std::vector<Requirement> GetRequirements(
+      const ::istio::mixer::v1::Attributes& attributes) const = 0;
+
+  // The factory function to create a new instance of the parser.
+  static std::unique_ptr<ConfigParser> Create(
+      const ::istio::mixer::v1::config::client::QuotaSpec& spec_pb);
+};
+
+}  // namespace quota
+}  // namespace istio
+
+#endif  // QUOTA_CONFIG_PARSER_H_

--- a/quota/include/requirement.h
+++ b/quota/include/requirement.h
@@ -1,0 +1,35 @@
+/* Copyright 2017 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef QUOTA_REQUIREMENT_H_
+#define QUOTA_REQUIREMENT_H_
+
+#include <string>
+
+namespace istio {
+namespace quota {
+
+// A struct to represent one quota requirement.
+struct Requirement {
+  // The quota name.
+  std::string quota;
+  // The amount to charge
+  int64_t charge;
+};
+
+}  // namespace quota
+}  // namespace istio
+
+#endif  // QUOTA_REQUIREMENT_H_

--- a/quota/src/config_parser_impl.cc
+++ b/quota/src/config_parser_impl.cc
@@ -1,0 +1,114 @@
+/* Copyright 2017 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "config_parser_impl.h"
+
+using ::istio::mixer::v1::Attributes;
+using ::istio::mixer::v1::Attributes_AttributeValue;
+using ::istio::mixer::v1::config::client::AttributeMatch;
+using ::istio::mixer::v1::config::client::StringMatch;
+using ::istio::mixer::v1::config::client::QuotaRule;
+using ::istio::mixer::v1::config::client::QuotaSpec;
+
+namespace istio {
+namespace quota {
+
+ConfigParserImpl::ConfigParserImpl(const QuotaSpec& spec_pb)
+    : spec_pb_(spec_pb) {
+  // Build regex map
+  for (const auto& rule : spec_pb_.rules()) {
+    for (const auto& match : rule.match()) {
+      for (const auto& map_it : match.clause()) {
+        const auto& match = map_it.second;
+        if (match.match_type_case() == StringMatch::kRegex) {
+          regex_map_[match.regex()] = std::regex(match.regex());
+        }
+      }
+    }
+  }
+}
+
+std::vector<Requirement> ConfigParserImpl::GetRequirements(
+    const Attributes& attributes) const {
+  std::vector<Requirement> results;
+  for (const auto& rule : spec_pb_.rules()) {
+    bool matched = false;
+    for (const auto& match : rule.match()) {
+      if (MatchAttributes(match, attributes)) {
+        matched = true;
+        break;
+      }
+    }
+    // If not match, applies to all requests.
+    if (matched || rule.match_size() == 0) {
+      for (const auto& quota : rule.quotas()) {
+        results.push_back({quota.quota(), quota.charge()});
+      }
+    }
+  }
+  return results;
+}
+
+bool ConfigParserImpl::MatchAttributes(const AttributeMatch& match,
+                                       const Attributes& attributes) const {
+  const auto& attributes_map = attributes.attributes();
+  for (const auto& map_it : match.clause()) {
+    // map is attribute_name to StringMatch.
+    const std::string& name = map_it.first;
+    const auto& match = map_it.second;
+
+    // Check if required attribure exists with string type.
+    const auto& it = attributes_map.find(name);
+    if (it == attributes_map.end() ||
+        it->second.value_case() != Attributes_AttributeValue::kStringValue) {
+      return false;
+    }
+    const std::string& value = it->second.string_value();
+
+    switch (match.match_type_case()) {
+      case StringMatch::kExact:
+        if (value != match.exact()) {
+          return false;
+        }
+        break;
+      case StringMatch::kPrefix:
+        if (value.length() < match.prefix().length() ||
+            value.compare(0, match.prefix().length(), match.prefix()) != 0) {
+          return false;
+        }
+        break;
+      case StringMatch::kRegex: {
+        const auto& reg_it = regex_map_.find(match.regex());
+        // All regex should be pre-build.
+        GOOGLE_CHECK(reg_it != regex_map_.end());
+        if (!std::regex_match(value, reg_it->second)) {
+          return false;
+        }
+      } break;
+      default:
+        // match_type not set case, an empty StringMatch, ignore it.
+        break;
+    }
+  }
+  return true;
+}
+
+std::unique_ptr<ConfigParser> ConfigParser::Create(
+    const ::istio::mixer::v1::config::client::QuotaSpec& spec_pb) {
+  return std::unique_ptr<ConfigParser>(new ConfigParserImpl(spec_pb));
+}
+
+}  // namespace quota
+}  // namespace istio

--- a/quota/src/config_parser_impl.h
+++ b/quota/src/config_parser_impl.h
@@ -1,0 +1,52 @@
+/* Copyright 2017 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef QUOTA_CONFIG_PARSER_IMPL_H_
+#define QUOTA_CONFIG_PARSER_IMPL_H_
+
+#include "quota/include/config_parser.h"
+
+#include <regex>
+#include <unordered_map>
+
+namespace istio {
+namespace quota {
+
+// An object to implement ConfigParser interface.
+class ConfigParserImpl : public ConfigParser {
+ public:
+  ConfigParserImpl(
+      const ::istio::mixer::v1::config::client::QuotaSpec& spec_pb);
+
+  // Get quota requirements for a attribute set.
+  std::vector<Requirement> GetRequirements(
+      const ::istio::mixer::v1::Attributes& attributes) const override;
+
+ private:
+  // Check one attribute match.
+  bool MatchAttributes(
+      const ::istio::mixer::v1::config::client::AttributeMatch& match,
+      const ::istio::mixer::v1::Attributes& attributes) const;
+  // the spec proto.
+  const ::istio::mixer::v1::config::client::QuotaSpec& spec_pb_;
+
+  // Stored regex objects.
+  std::unordered_map<std::string, std::regex> regex_map_;
+};
+
+}  // namespace quota
+}  // namespace istio
+
+#endif  // QUOTA_CONFIG_PARSER_IMPL_H_

--- a/quota/src/config_parser_impl_test.cc
+++ b/quota/src/config_parser_impl_test.cc
@@ -1,0 +1,173 @@
+/* Copyright 2017 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "quota/include/config_parser.h"
+
+#include "google/protobuf/text_format.h"
+#include "gtest/gtest.h"
+#include "include/attributes_builder.h"
+
+using ::istio::mixer::v1::Attributes;
+using ::istio::mixer_client::AttributesBuilder;
+using ::google::protobuf::TextFormat;
+using ::istio::mixer::v1::config::client::QuotaSpec;
+
+namespace istio {
+namespace quota {
+namespace {
+
+const char kQuotaEmptyMatch[] = R"(
+rules {
+  quotas {
+    quota: "quota1"
+    charge: 1
+  }
+  quotas {
+    quota: "quota2"
+    charge: 2
+  }
+}
+)";
+
+const char kQuotaMatch[] = R"(
+rules {
+  match {
+    clause {
+      key: "request.http_method"
+      value {
+        exact: "GET"
+      }
+    }
+    clause {
+      key: "request.path"
+      value {
+        prefix: "/books"
+      }
+    }
+  }
+  match {
+    clause {
+      key: "api.operation"
+      value {
+        exact: "get_books"
+      }
+    }
+  }
+  quotas {
+    quota: "quota-name"
+    charge: 1
+  }
+}
+)";
+
+const char kQuotaRegexMatch[] = R"(
+rules {
+  match {
+    clause {
+      key: "request.path"
+      value {
+        regex: "/shelves/.*/books"
+      }
+    }
+  }
+  quotas {
+    quota: "quota-name"
+    charge: 1
+  }
+}
+)";
+
+// Define similar data structure for quota requirement
+// But this one has operator== for comparison so that EXPECT_EQ
+// can directly use its vector.
+struct Quota {
+  std::string quota;
+  int64_t charge;
+
+  bool operator==(const Quota& v) const {
+    return quota == v.quota && charge == v.charge;
+  }
+};
+
+// A short name for the vector.
+using QV = std::vector<Quota>;
+
+// Converts the vector of Requirement to vector of Quota
+std::vector<Quota> ToQV(const std::vector<Requirement>& src) {
+  std::vector<Quota> v;
+  for (const auto& it : src) {
+    v.push_back({it.quota, it.charge});
+  }
+  return v;
+}
+
+TEST(ConfigParserTest, TestEmptyMatch) {
+  QuotaSpec quota_spec;
+  ASSERT_TRUE(TextFormat::ParseFromString(kQuotaEmptyMatch, &quota_spec));
+  auto parser = ConfigParser::Create(quota_spec);
+
+  Attributes attributes;
+  // If match clause is empty, it matches all requests.
+  ASSERT_EQ(ToQV(parser->GetRequirements(attributes)),
+            QV({{"quota1", 1}, {"quota2", 2}}));
+}
+
+TEST(ConfigParserTest, TestMatch) {
+  QuotaSpec quota_spec;
+  ASSERT_TRUE(TextFormat::ParseFromString(kQuotaMatch, &quota_spec));
+  auto parser = ConfigParser::Create(quota_spec);
+
+  Attributes attributes;
+  AttributesBuilder builder(&attributes);
+  ASSERT_EQ(ToQV(parser->GetRequirements(attributes)), QV());
+
+  // Wrong http_method
+  builder.AddString("request.http_method", "POST");
+  builder.AddString("request.path", "/books/1");
+  ASSERT_EQ(ToQV(parser->GetRequirements(attributes)), QV());
+
+  // Matched
+  builder.AddString("request.http_method", "GET");
+  ASSERT_EQ(ToQV(parser->GetRequirements(attributes)), QV({{"quota-name", 1}}));
+
+  attributes.mutable_attributes()->clear();
+  // Wrong api.operation
+  builder.AddString("api.operation", "get_shelves");
+  ASSERT_EQ(ToQV(parser->GetRequirements(attributes)), QV());
+
+  // Matched
+  builder.AddString("api.operation", "get_books");
+  ASSERT_EQ(ToQV(parser->GetRequirements(attributes)), QV({{"quota-name", 1}}));
+}
+
+TEST(ConfigParserTest, TestRegexMatch) {
+  QuotaSpec quota_spec;
+  ASSERT_TRUE(TextFormat::ParseFromString(kQuotaRegexMatch, &quota_spec));
+  auto parser = ConfigParser::Create(quota_spec);
+
+  Attributes attributes;
+  AttributesBuilder builder(&attributes);
+  // Not match
+  builder.AddString("request.path", "/shelves/1/bar");
+  ASSERT_EQ(ToQV(parser->GetRequirements(attributes)), QV());
+
+  // match
+  builder.AddString("request.path", "/shelves/10/books");
+  ASSERT_EQ(ToQV(parser->GetRequirements(attributes)), QV({{"quota-name", 1}}));
+}
+
+}  // namespace
+}  // namespace quota
+}  // namespace istio


### PR DESCRIPTION
Just moved the code from istio/proxy:src/envoy/mixer to istio/mixerclient
* Changed the namespace.  
* Added a map to re-load std::regex objects for optimization.

The reason that the include/requirement.h is in its own header library is because this header file may be used by mixerclient/client.h directly  to pass quota requirement to quota cache code.