### PR TITLE
Separate quota requirements from attributes.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -71,9 +71,10 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":simple_lru_cache",
-        "//prefetch:quota_prefetch_lib",
         "//external:boringssl_crypto",
         "//external:mixer_api_cc_proto",
+        "//prefetch:quota_prefetch_lib",
+        "//quota:requirement_header",
     ],
 )
 

--- a/control/include/http/controller.h
+++ b/control/include/http/controller.h
@@ -52,11 +52,15 @@ class Controller {
   // * client_config: the mixer client config.
   // * some functions provided by the environment (Envoy)
   struct Options {
-    Options(const ::istio::mixer::v1::config::client::HttpClientConfig& config)
-        : config(config) {}
+    Options(const ::istio::mixer::v1::config::client::HttpClientConfig& config,
+            const std::vector<::istio::quota::Requirement>& legacy_quotas)
+        : config(config), legacy_quotas(legacy_quotas) {}
 
     // Mixer filter config
     const ::istio::mixer::v1::config::client::HttpClientConfig& config;
+
+    // Legacy mixer config quota requirements.
+    const std::vector<::istio::quota::Requirement>& legacy_quotas;
 
     // Some plaform functions for mixer client library.
     ::istio::mixer_client::Environment env;

--- a/control/src/client_context_base.cc
+++ b/control/src/client_context_base.cc
@@ -69,9 +69,10 @@ ClientContextBase::ClientContextBase(const TransportConfig& config,
   mixer_client_ = ::istio::mixer_client::CreateMixerClient(options);
 }
 
-CancelFunc ClientContextBase::SendCheck(TransportCheckFunc transport,
-                                        DoneFunc on_done,
-                                        RequestContext* request) {
+CancelFunc ClientContextBase::SendCheck(
+    TransportCheckFunc transport, DoneFunc on_done,
+    const std::vector<::istio::quota::Requirement>& quotas,
+    RequestContext* request) {
   // Intercept the callback to save check status in request_context
   auto local_on_done = [request, on_done](const Status& status) {
     // save the check status code
@@ -82,7 +83,8 @@ CancelFunc ClientContextBase::SendCheck(TransportCheckFunc transport,
   // TODO: add debug message
   // GOOGLE_LOG(INFO) << "Check attributes: " <<
   // request->attributes.DebugString();
-  return mixer_client_->Check(request->attributes, transport, local_on_done);
+  return mixer_client_->Check(request->attributes, quotas, transport,
+                              local_on_done);
 }
 
 void ClientContextBase::SendReport(const RequestContext& request) {

--- a/control/src/client_context_base.h
+++ b/control/src/client_context_base.h
@@ -41,7 +41,9 @@ class ClientContextBase {
   // Use mixer client object to make a Check call.
   ::istio::mixer_client::CancelFunc SendCheck(
       ::istio::mixer_client::TransportCheckFunc transport,
-      ::istio::mixer_client::DoneFunc on_done, RequestContext* request);
+      ::istio::mixer_client::DoneFunc on_done,
+      const std::vector<::istio::quota::Requirement>& quotas,
+      RequestContext* request);
 
   // Use mixer client object to make a Report call.
   void SendReport(const RequestContext& request);

--- a/control/src/http/client_context.h
+++ b/control/src/http/client_context.h
@@ -30,22 +30,33 @@ class ClientContext : public ClientContextBase {
  public:
   ClientContext(const Controller::Options& data)
       : ClientContextBase(data.config.transport(), data.env),
-        config_(data.config) {}
+        config_(data.config),
+        legacy_quotas_(data.legacy_quotas) {}
 
   // A constructor for unit-test to pass in a mock mixer_client
   ClientContext(
       std::unique_ptr<::istio::mixer_client::MixerClient> mixer_client,
-      const ::istio::mixer::v1::config::client::HttpClientConfig& config)
-      : ClientContextBase(std::move(mixer_client)), config_(config) {}
+      const ::istio::mixer::v1::config::client::HttpClientConfig& config,
+      const std::vector<::istio::quota::Requirement>& legacy_quotas)
+      : ClientContextBase(std::move(mixer_client)),
+        config_(config),
+        legacy_quotas_(legacy_quotas) {}
 
   // Retrieve mixer client config.
   const ::istio::mixer::v1::config::client::HttpClientConfig& config() const {
     return config_;
   }
 
+  const std::vector<::istio::quota::Requirement>& legacy_quotas() const {
+    return legacy_quotas_;
+  }
+
  private:
   // The http client config.
   const ::istio::mixer::v1::config::client::HttpClientConfig& config_;
+
+  // Legacy mixer config quota requirements.
+  const std::vector<::istio::quota::Requirement>& legacy_quotas_;
 };
 
 }  // namespace http

--- a/control/src/http/request_handler_impl.cc
+++ b/control/src/http/request_handler_impl.cc
@@ -20,6 +20,7 @@ using ::google::protobuf::util::Status;
 using ::istio::mixer_client::CancelFunc;
 using ::istio::mixer_client::TransportCheckFunc;
 using ::istio::mixer_client::DoneFunc;
+using ::istio::quota::Requirement;
 
 namespace istio {
 namespace mixer_control {
@@ -52,8 +53,10 @@ CancelFunc RequestHandlerImpl::Check(CheckData* check_data,
     return nullptr;
   }
 
-  return service_context_->client_context()->SendCheck(transport, on_done,
-                                                       &request_context_);
+  std::vector<Requirement> quotas(
+      service_context_->client_context()->legacy_quotas());
+  return service_context_->client_context()->SendCheck(
+      transport, on_done, quotas, &request_context_);
 }
 
 // Make remote report call.

--- a/control/src/mock_mixer_client.h
+++ b/control/src/mock_mixer_client.h
@@ -25,10 +25,12 @@ namespace mixer_control {
 // The mock object for MixerClient interface.
 class MockMixerClient : public ::istio::mixer_client::MixerClient {
  public:
-  MOCK_METHOD3(Check, ::istio::mixer_client::CancelFunc(
-                          const ::istio::mixer::v1::Attributes& attributes,
-                          ::istio::mixer_client::TransportCheckFunc transport,
-                          ::istio::mixer_client::DoneFunc on_done));
+  MOCK_METHOD4(Check,
+               ::istio::mixer_client::CancelFunc(
+                   const ::istio::mixer::v1::Attributes& attributes,
+                   const std::vector<::istio::quota::Requirement>& quotas,
+                   ::istio::mixer_client::TransportCheckFunc transport,
+                   ::istio::mixer_client::DoneFunc on_done));
   MOCK_METHOD1(Report, void(const ::istio::mixer::v1::Attributes& attributes));
 };
 

--- a/control/src/tcp/request_handler_impl.cc
+++ b/control/src/tcp/request_handler_impl.cc
@@ -19,6 +19,7 @@
 using ::google::protobuf::util::Status;
 using ::istio::mixer_client::CancelFunc;
 using ::istio::mixer_client::DoneFunc;
+using ::istio::quota::Requirement;
 
 namespace istio {
 namespace mixer_control {
@@ -42,7 +43,9 @@ CancelFunc RequestHandlerImpl::Check(CheckData* check_data, DoneFunc on_done) {
     return nullptr;
   }
 
-  return client_context_->SendCheck(nullptr, on_done, &request_context_);
+  std::vector<Requirement> quotas;
+  return client_context_->SendCheck(nullptr, on_done, quotas,
+                                    &request_context_);
 }
 
 // Make remote report call.

--- a/control/src/tcp/request_handler_impl_test.cc
+++ b/control/src/tcp/request_handler_impl_test.cc
@@ -52,7 +52,7 @@ TEST_F(RequestHandlerImplTest, TestHandlerDisabledCheck) {
   EXPECT_CALL(mock_data, GetSourceUser(_)).Times(1);
 
   // Check should not be called.
-  EXPECT_CALL(*mock_client_, Check(_, _, _)).Times(0);
+  EXPECT_CALL(*mock_client_, Check(_, _, _, _)).Times(0);
 
   client_config_.set_disable_check_calls(true);
   auto handler = controller_->CreateRequestHandler();
@@ -66,7 +66,7 @@ TEST_F(RequestHandlerImplTest, TestHandlerCheck) {
   EXPECT_CALL(mock_data, GetSourceUser(_)).Times(1);
 
   // Check should be called.
-  EXPECT_CALL(*mock_client_, Check(_, _, _)).Times(1);
+  EXPECT_CALL(*mock_client_, Check(_, _, _, _)).Times(1);
 
   auto handler = controller_->CreateRequestHandler();
   handler->Check(&mock_data, nullptr);

--- a/include/client.h
+++ b/include/client.h
@@ -18,6 +18,9 @@
 
 #include "environment.h"
 #include "options.h"
+#include "quota/include/requirement.h"
+
+#include <vector>
 
 namespace istio {
 namespace mixer_client {
@@ -59,8 +62,10 @@ class MixerClient {
   // The response data from mixer will be consumed by mixer client.
 
   // A check call.
-  virtual CancelFunc Check(const ::istio::mixer::v1::Attributes& attributes,
-                           TransportCheckFunc transport, DoneFunc on_done) = 0;
+  virtual CancelFunc Check(
+      const ::istio::mixer::v1::Attributes& attributes,
+      const std::vector<::istio::quota::Requirement>& quotas,
+      TransportCheckFunc transport, DoneFunc on_done) = 0;
 
   // A report call.
   virtual void Report(const ::istio::mixer::v1::Attributes& attributes) = 0;

--- a/src/client_impl.cc
+++ b/src/client_impl.cc
@@ -43,9 +43,10 @@ MixerClientImpl::MixerClientImpl(const MixerClientOptions &options)
 
 MixerClientImpl::~MixerClientImpl() {}
 
-CancelFunc MixerClientImpl::Check(const Attributes &attributes,
-                                  TransportCheckFunc transport,
-                                  DoneFunc on_done) {
+CancelFunc MixerClientImpl::Check(
+    const Attributes &attributes,
+    const std::vector<::istio::quota::Requirement> &quotas,
+    TransportCheckFunc transport, DoneFunc on_done) {
   std::unique_ptr<CheckCache::CheckResult> check_result(
       new CheckCache::CheckResult);
   check_cache_->Check(attributes, check_result.get());
@@ -59,7 +60,7 @@ CancelFunc MixerClientImpl::Check(const Attributes &attributes,
   // Only use quota cache if Check is using cache with OK status.
   // Otherwise, a remote Check call may be rejected, but quota amounts were
   // substracted from quota cache already.
-  quota_cache_->Check(attributes, check_result->IsCacheHit(),
+  quota_cache_->Check(attributes, quotas, check_result->IsCacheHit(),
                       quota_result.get());
 
   CheckRequest request;

--- a/src/client_impl.h
+++ b/src/client_impl.h
@@ -35,8 +35,10 @@ class MixerClientImpl : public MixerClient {
   // Destructor
   virtual ~MixerClientImpl();
 
-  virtual CancelFunc Check(const ::istio::mixer::v1::Attributes& attributes,
-                           TransportCheckFunc transport, DoneFunc on_done);
+  virtual CancelFunc Check(
+      const ::istio::mixer::v1::Attributes& attributes,
+      const std::vector<::istio::quota::Requirement>& quotas,
+      TransportCheckFunc transport, DoneFunc on_done);
   virtual void Report(const ::istio::mixer::v1::Attributes& attributes);
 
  private:

--- a/src/client_impl_test.cc
+++ b/src/client_impl_test.cc
@@ -50,8 +50,7 @@ class MockCheckTransport {
 class MixerClientImplTest : public ::testing::Test {
  public:
   MixerClientImplTest() {
-    AttributesBuilder(&request_).AddString("quota.name", kRequestCount);
-
+    quotas_.push_back({kRequestCount, 1});
     CreateClient(true /* check_cache */, true /* quota_cache */);
   }
 
@@ -80,17 +79,17 @@ TEST_F(MixerClientImplTest, TestSuccessCheck) {
         on_done(Status::OK);
       }));
 
-  // Remove quota, not to test quota
-  request_.mutable_attributes()->erase("quota.name");
+  // Not to test quota
+  std::vector<Requirement> empty_quotas;
   Status done_status = Status::UNKNOWN;
-  client_->Check(request_, quotas_, empty_transport_,
+  client_->Check(request_, empty_quotas, empty_transport_,
                  [&done_status](Status status) { done_status = status; });
   EXPECT_TRUE(done_status.ok());
 
   for (int i = 0; i < 10; i++) {
     // Other calls should ba cached.
     Status done_status1 = Status::UNKNOWN;
-    client_->Check(request_, quotas_, empty_transport_,
+    client_->Check(request_, empty_quotas, empty_transport_,
                    [&done_status1](Status status) { done_status1 = status; });
     EXPECT_TRUE(done_status1.ok());
   }
@@ -109,17 +108,17 @@ TEST_F(MixerClientImplTest, TestPerRequestTransport) {
         on_done(Status::OK);
       }));
 
-  // Remove quota, not to test quota
-  request_.mutable_attributes()->erase("quota.name");
+  // Not to test quota
+  std::vector<Requirement> empty_quotas;
   Status done_status = Status::UNKNOWN;
-  client_->Check(request_, quotas_, local_check_transport.GetFunc(),
+  client_->Check(request_, empty_quotas, local_check_transport.GetFunc(),
                  [&done_status](Status status) { done_status = status; });
   EXPECT_TRUE(done_status.ok());
 
   for (int i = 0; i < 10; i++) {
     // Other calls should ba cached.
     Status done_status1 = Status::UNKNOWN;
-    client_->Check(request_, quotas_, local_check_transport.GetFunc(),
+    client_->Check(request_, empty_quotas, local_check_transport.GetFunc(),
                    [&done_status1](Status status) { done_status1 = status; });
     EXPECT_TRUE(done_status1.ok());
   }

--- a/src/quota_cache.cc
+++ b/src/quota_cache.cc
@@ -21,6 +21,7 @@ using ::istio::mixer::v1::Attributes;
 using ::istio::mixer::v1::Attributes_AttributeValue;
 using ::istio::mixer::v1::CheckRequest;
 using ::istio::mixer::v1::CheckResponse;
+using ::istio::quota::Requirement;
 using ::google::protobuf::util::Status;
 using ::google::protobuf::util::error::Code;
 
@@ -242,31 +243,11 @@ void QuotaCache::SetResponse(const Attributes& attributes,
   cache_->Insert(signature, quota_ref.pending_item.release(), 1);
 }
 
-void QuotaCache::Check(const Attributes& request, bool use_cache,
+void QuotaCache::Check(const Attributes& request,
+                       const std::vector<Requirement>& quotas, bool use_cache,
                        CheckResult* result) {
-  // Now, there is only one quota metric for a request.
-  // But it should be very easy to support multiple quota metrics.
-  static const std::vector<std::pair<std::string, std::string>>
-      kQuotaAttributes{{kQuotaName, kQuotaAmount}};
-  const auto& attributes_map = request.attributes();
-  for (const auto& pair : kQuotaAttributes) {
-    const std::string& name_attr = pair.first;
-    const std::string& amount_attr = pair.second;
-    const auto& name_it = attributes_map.find(name_attr);
-    if (name_it == attributes_map.end() ||
-        name_it->second.value_case() !=
-            Attributes_AttributeValue::kStringValue) {
-      continue;
-    }
-    CheckResult::Quota quota;
-    quota.name = name_it->second.string_value();
-    quota.amount = 1;
-    const auto& amount_it = attributes_map.find(amount_attr);
-    if (amount_it != attributes_map.end() &&
-        amount_it->second.value_case() ==
-            Attributes_AttributeValue::kInt64Value) {
-      quota.amount = amount_it->second.int64_value();
-    }
+  for (const auto& requirement : quotas) {
+    CheckResult::Quota quota = {requirement.quota, requirement.charge};
     CheckCache(request, use_cache, &quota);
     result->quotas_.push_back(quota);
   }

--- a/src/quota_cache.cc
+++ b/src/quota_cache.cc
@@ -27,10 +27,6 @@ using ::google::protobuf::util::error::Code;
 
 namespace istio {
 namespace mixer_client {
-namespace {
-const std::string kQuotaName = "quota.name";
-const std::string kQuotaAmount = "quota.amount";
-}
 
 QuotaCache::CacheElem::CacheElem(const std::string& name) : name_(name) {
   prefetch_ = QuotaPrefetch::Create(

--- a/src/quota_cache.h
+++ b/src/quota_cache.h
@@ -68,7 +68,7 @@ class QuotaCache {
     // Hold pending quota data needed to talk to server.
     struct Quota {
       std::string name;
-      uint64_t amount;
+      int64_t amount;
       bool best_effort;
 
       enum Result {

--- a/src/quota_cache.h
+++ b/src/quota_cache.h
@@ -92,8 +92,9 @@ class QuotaCache {
   };
 
   // Check quota cache for a request, result will be stored in CacaheResult.
-  void Check(const ::istio::mixer::v1::Attributes& request, bool use_cache,
-             CheckResult* result);
+  void Check(const ::istio::mixer::v1::Attributes& request,
+             const std::vector<::istio::quota::Requirement>& quotas,
+             bool use_cache, CheckResult* result);
 
  private:
   // Check quota cache.


### PR DESCRIPTION
It used to be in the attributes,  used hardcoded  "quota.name" and "quota.amount" attributes to only pass one requirement. 
Now changed to use vector to pass quota requirement in the Check call to client.