### PR TITLE
fix compilation with g++ 7.2.0

### DIFF
--- a/include/timer.h
+++ b/include/timer.h
@@ -17,6 +17,7 @@
 #define MIXERCLIENT_TIMER_H
 
 #include <memory>
+#include <functional>
 
 namespace istio {
 namespace mixer_client {


### PR DESCRIPTION
fails to compile on ubuntu 17.10
g++ (Ubuntu 7.2.0-8ubuntu3) 7.2.0
because of undefined std::function. adding the header fixes this.