### PR TITLE
Integrate with quota parser

### DIFF
--- a/control/include/http/controller.h
+++ b/control/include/http/controller.h
@@ -38,7 +38,7 @@ class Controller {
     std::string destination_service;
 
     // if not NULL, legacy per-route config for 0.2 and before.
-    const ::istio::mixer::v1::config::client::ServiceConfig* legacy_config;
+    const ::istio::mixer::v1::config::client::ServiceConfig* legacy_config{};
   };
 
   // Creates a HTTP request handler.

--- a/control/src/BUILD
+++ b/control/src/BUILD
@@ -28,6 +28,7 @@ cc_library(
     visibility = [":__subpackages__"],
     deps = [
         "//:mixer_client_lib",
+        "//quota:config_parser_lib",
         "//external:mixer_client_config_cc_proto",
     ],
 )

--- a/control/src/client_context_base.cc
+++ b/control/src/client_context_base.cc
@@ -69,10 +69,9 @@ ClientContextBase::ClientContextBase(const TransportConfig& config,
   mixer_client_ = ::istio::mixer_client::CreateMixerClient(options);
 }
 
-CancelFunc ClientContextBase::SendCheck(
-    TransportCheckFunc transport, DoneFunc on_done,
-    const std::vector<::istio::quota::Requirement>& quotas,
-    RequestContext* request) {
+CancelFunc ClientContextBase::SendCheck(TransportCheckFunc transport,
+                                        DoneFunc on_done,
+                                        RequestContext* request) {
   // Intercept the callback to save check status in request_context
   auto local_on_done = [request, on_done](const Status& status) {
     // save the check status code
@@ -83,7 +82,7 @@ CancelFunc ClientContextBase::SendCheck(
   // TODO: add debug message
   // GOOGLE_LOG(INFO) << "Check attributes: " <<
   // request->attributes.DebugString();
-  return mixer_client_->Check(request->attributes, quotas, transport,
+  return mixer_client_->Check(request->attributes, request->quotas, transport,
                               local_on_done);
 }
 

--- a/control/src/client_context_base.h
+++ b/control/src/client_context_base.h
@@ -41,9 +41,7 @@ class ClientContextBase {
   // Use mixer client object to make a Check call.
   ::istio::mixer_client::CancelFunc SendCheck(
       ::istio::mixer_client::TransportCheckFunc transport,
-      ::istio::mixer_client::DoneFunc on_done,
-      const std::vector<::istio::quota::Requirement>& quotas,
-      RequestContext* request);
+      ::istio::mixer_client::DoneFunc on_done, RequestContext* request);
 
   // Use mixer client object to make a Report call.
   void SendReport(const RequestContext& request);

--- a/control/src/http/BUILD
+++ b/control/src/http/BUILD
@@ -19,12 +19,14 @@ cc_library(
     srcs = [
         "attributes_builder.cc",
         "attributes_builder.h",
+        "client_context.cc",
         "client_context.h",
         "controller_impl.cc",
         "controller_impl.h",
         "request_handler_impl.cc",
         "request_handler_impl.h",
-        "service_context.h"
+        "service_context.cc",
+        "service_context.h",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/control/src/http/client_context.cc
+++ b/control/src/http/client_context.cc
@@ -1,0 +1,67 @@
+/* Copyright 2017 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "client_context.h"
+
+using ::istio::mixer::v1::config::client::ServiceConfig;
+
+namespace istio {
+namespace mixer_control {
+namespace http {
+
+ClientContext::ClientContext(const Controller::Options& data)
+    : ClientContextBase(data.config.transport(), data.env),
+      config_(data.config),
+      legacy_quotas_(data.legacy_quotas) {}
+
+ClientContext::ClientContext(
+    std::unique_ptr<::istio::mixer_client::MixerClient> mixer_client,
+    const ::istio::mixer::v1::config::client::HttpClientConfig& config,
+    const std::vector<::istio::quota::Requirement>& legacy_quotas)
+    : ClientContextBase(std::move(mixer_client)),
+      config_(config),
+      legacy_quotas_(legacy_quotas) {}
+
+void ClientContext::AddLegacyQuotas(
+    std::vector<::istio::quota::Requirement>* quotas) const {
+  quotas->insert(quotas->end(), legacy_quotas_.begin(), legacy_quotas_.end());
+}
+
+const std::string& ClientContext::GetServiceName(
+    const std::string& service_name) const {
+  if (service_name.empty()) {
+    return config_.default_destination_service();
+  }
+  const auto& config_map = config_.service_configs();
+  auto it = config_map.find(service_name);
+  if (it == config_map.end()) {
+    return config_.default_destination_service();
+  }
+  return service_name;
+}
+
+// Get the service config by the name.
+const ServiceConfig& ClientContext::GetServiceConfig(
+    const std::string& service_name) const {
+  const auto& config_map = config_.service_configs();
+  auto it = config_map.find(service_name);
+  // The name should be a valid one checked by GetServiceName()
+  GOOGLE_CHECK(it != config_map.end());
+  return it->second;
+}
+
+}  // namespace http
+}  // namespace mixer_control
+}  // namespace istio

--- a/control/src/http/client_context.h
+++ b/control/src/http/client_context.h
@@ -47,8 +47,31 @@ class ClientContext : public ClientContextBase {
     return config_;
   }
 
-  const std::vector<::istio::quota::Requirement>& legacy_quotas() const {
-    return legacy_quotas_;
+  // Append the legacy quotas.
+  void AddLegacyQuotas(std::vector<::istio::quota::Requirement>* quotas) const {
+    quotas->insert(quotas->end(), legacy_quotas_.begin(), legacy_quotas_.end());
+  }
+
+  // Get valid service name in the config map.
+  // If input service name is in the map, use it, otherwise, use the default
+  // one.
+  const std::string& GetServiceName(const std::string& service_name) const {
+    const auto& config_map = config_.service_configs();
+    auto it = config_map.find(service_name);
+    if (it == config_map.end()) {
+      return config_.default_destination_service();
+    }
+    return service_name;
+  }
+
+  // Get the service config by the name.
+  const ::istio::mixer::v1::config::client::ServiceConfig& GetServiceConfig(
+      const std::string& service_name) const {
+    const auto& config_map = config_.service_configs();
+    auto it = config_map.find(service_name);
+    // The name should be a valid one checked by GetServiceName()
+    GOOGLE_CHECK(it != config_map.end());
+    return it->second;
   }
 
  private:

--- a/control/src/http/client_context.h
+++ b/control/src/http/client_context.h
@@ -28,19 +28,12 @@ namespace http {
 // * the mixer client object to call Check/Report with cache.
 class ClientContext : public ClientContextBase {
  public:
-  ClientContext(const Controller::Options& data)
-      : ClientContextBase(data.config.transport(), data.env),
-        config_(data.config),
-        legacy_quotas_(data.legacy_quotas) {}
-
+  ClientContext(const Controller::Options& data);
   // A constructor for unit-test to pass in a mock mixer_client
   ClientContext(
       std::unique_ptr<::istio::mixer_client::MixerClient> mixer_client,
       const ::istio::mixer::v1::config::client::HttpClientConfig& config,
-      const std::vector<::istio::quota::Requirement>& legacy_quotas)
-      : ClientContextBase(std::move(mixer_client)),
-        config_(config),
-        legacy_quotas_(legacy_quotas) {}
+      const std::vector<::istio::quota::Requirement>& legacy_quotas);
 
   // Retrieve mixer client config.
   const ::istio::mixer::v1::config::client::HttpClientConfig& config() const {
@@ -48,31 +41,16 @@ class ClientContext : public ClientContextBase {
   }
 
   // Append the legacy quotas.
-  void AddLegacyQuotas(std::vector<::istio::quota::Requirement>* quotas) const {
-    quotas->insert(quotas->end(), legacy_quotas_.begin(), legacy_quotas_.end());
-  }
+  void AddLegacyQuotas(std::vector<::istio::quota::Requirement>* quotas) const;
 
   // Get valid service name in the config map.
   // If input service name is in the map, use it, otherwise, use the default
   // one.
-  const std::string& GetServiceName(const std::string& service_name) const {
-    const auto& config_map = config_.service_configs();
-    auto it = config_map.find(service_name);
-    if (it == config_map.end()) {
-      return config_.default_destination_service();
-    }
-    return service_name;
-  }
+  const std::string& GetServiceName(const std::string& service_name) const;
 
   // Get the service config by the name.
   const ::istio::mixer::v1::config::client::ServiceConfig& GetServiceConfig(
-      const std::string& service_name) const {
-    const auto& config_map = config_.service_configs();
-    auto it = config_map.find(service_name);
-    // The name should be a valid one checked by GetServiceName()
-    GOOGLE_CHECK(it != config_map.end());
-    return it->second;
-  }
+      const std::string& service_name) const;
 
  private:
   // The http client config.

--- a/control/src/http/controller_impl.cc
+++ b/control/src/http/controller_impl.cc
@@ -40,13 +40,18 @@ std::shared_ptr<ServiceContext> ControllerImpl::GetServiceContext(
                                             *config.legacy_config);
   }
 
-  auto service_name =
-      client_context_->GetServiceName(config.destination_service);
-  auto service_context = service_context_map_[service_name];
+  const std::string& origin_name = config.destination_service;
+  auto service_context = service_context_map_[origin_name];
   if (!service_context) {
-    service_context = std::make_shared<ServiceContext>(
-        client_context_, client_context_->GetServiceConfig(service_name));
-    service_context_map_[service_name] = service_context;
+    // Get the valid service name from service_configs map.
+    auto valid_name = client_context_->GetServiceName(origin_name);
+    service_context = service_context_map_[valid_name];
+    if (!service_context) {
+      service_context = std::make_shared<ServiceContext>(
+          client_context_, client_context_->GetServiceConfig(valid_name));
+      service_context_map_[valid_name] = service_context;
+    }
+    service_context_map_[origin_name] = service_context;
   }
   return service_context;
 }

--- a/control/src/http/controller_impl.cc
+++ b/control/src/http/controller_impl.cc
@@ -39,14 +39,16 @@ std::shared_ptr<ServiceContext> ControllerImpl::GetServiceContext(
     return std::make_shared<ServiceContext>(client_context_,
                                             *config.legacy_config);
   }
-  auto config_map = client_context_->config().service_configs();
-  auto it = config_map.find(config.destination_service);
-  if (it == config_map.end()) {
-    it = config_map.find(
-        client_context_->config().default_destination_service());
+
+  auto service_name =
+      client_context_->GetServiceName(config.destination_service);
+  auto service_context = service_context_map_[service_name];
+  if (!service_context) {
+    service_context = std::make_shared<ServiceContext>(
+        client_context_, client_context_->GetServiceConfig(service_name));
+    service_context_map_[service_name] = service_context;
   }
-  // TODO: cache this service context.
-  return std::make_shared<ServiceContext>(client_context_, it->second);
+  return service_context;
 }
 
 std::unique_ptr<Controller> Controller::Create(const Options& data) {

--- a/control/src/http/controller_impl.h
+++ b/control/src/http/controller_impl.h
@@ -17,6 +17,7 @@
 #define MIXERCONTROL_HTTP_CONTROLLER_IMPL_H
 
 #include <memory>
+#include <unordered_map>
 
 #include "client_context.h"
 #include "control/include/http/controller.h"
@@ -45,6 +46,10 @@ class ControllerImpl : public Controller {
 
   // The client context object to hold client config and client cache.
   std::shared_ptr<ClientContext> client_context_;
+
+  // The map to cache service context. key is destination.service
+  std::unordered_map<std::string, std::shared_ptr<ServiceContext>>
+      service_context_map_;
 };
 
 }  // namespace http

--- a/control/src/http/request_handler_impl.cc
+++ b/control/src/http/request_handler_impl.cc
@@ -53,10 +53,11 @@ CancelFunc RequestHandlerImpl::Check(CheckData* check_data,
     return nullptr;
   }
 
-  std::vector<Requirement> quotas(
-      service_context_->client_context()->legacy_quotas());
-  return service_context_->client_context()->SendCheck(
-      transport, on_done, quotas, &request_context_);
+  service_context_->client_context()->AddLegacyQuotas(&request_context_.quotas);
+  service_context_->AddQuotas(&request_context_);
+
+  return service_context_->client_context()->SendCheck(transport, on_done,
+                                                       &request_context_);
 }
 
 // Make remote report call.

--- a/control/src/http/service_context.cc
+++ b/control/src/http/service_context.cc
@@ -1,0 +1,54 @@
+/* Copyright 2017 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "service_context.h"
+
+using ::istio::mixer::v1::config::client::ServiceConfig;
+
+namespace istio {
+namespace mixer_control {
+namespace http {
+
+ServiceContext::ServiceContext(std::shared_ptr<ClientContext> client_context,
+                               const ServiceConfig& config)
+    : client_context_(client_context), service_config_(config) {
+  // Merge client config mixer attributes.
+  service_config_.mutable_mixer_attributes()->MergeFrom(
+      client_context->config().mixer_attributes());
+
+  // Build quota parser
+  for (const auto& quota : service_config_.quota_spec()) {
+    quota_parsers_.push_back(
+        std::move(::istio::quota::ConfigParser::Create(quota)));
+  }
+}
+
+// Add static mixer attributes.
+void ServiceContext::AddStaticAttributes(RequestContext* request) const {
+  if (service_config_.has_mixer_attributes()) {
+    request->attributes.MergeFrom(service_config_.mixer_attributes());
+  }
+}
+
+// Add quota requirements from quota configs.
+void ServiceContext::AddQuotas(RequestContext* request) const {
+  for (const auto& parser : quota_parsers_) {
+    parser->GetRequirements(request->attributes, &request->quotas);
+  }
+}
+
+}  // namespace http
+}  // namespace mixer_control
+}  // namespace istio

--- a/control/src/http/service_context.h
+++ b/control/src/http/service_context.h
@@ -30,36 +30,17 @@ class ServiceContext {
  public:
   ServiceContext(
       std::shared_ptr<ClientContext> client_context,
-      const ::istio::mixer::v1::config::client::ServiceConfig& config)
-      : client_context_(client_context), service_config_(config) {
-    // Merge client config mixer attributes.
-    service_config_.mutable_mixer_attributes()->MergeFrom(
-        client_context->config().mixer_attributes());
-
-    // Build quota parser
-    for (const auto& quota : service_config_.quota_spec()) {
-      quota_parsers_.push_back(
-          std::move(::istio::quota::ConfigParser::Create(quota)));
-    }
-  }
+      const ::istio::mixer::v1::config::client::ServiceConfig& config);
 
   std::shared_ptr<ClientContext> client_context() const {
     return client_context_;
   }
 
   // Add static mixer attributes.
-  void AddStaticAttributes(RequestContext* request) const {
-    if (service_config_.has_mixer_attributes()) {
-      request->attributes.MergeFrom(service_config_.mixer_attributes());
-    }
-  }
+  void AddStaticAttributes(RequestContext* request) const;
 
   // Add quota requirements from quota configs.
-  void AddQuotas(RequestContext* request) const {
-    for (const auto& parser : quota_parsers_) {
-      parser->GetRequirements(request->attributes, &request->quotas);
-    }
-  }
+  void AddQuotas(RequestContext* request) const;
 
   bool enable_mixer_check() const {
     return service_config_.enable_mixer_check();

--- a/control/src/request_context.h
+++ b/control/src/request_context.h
@@ -18,6 +18,9 @@
 
 #include "google/protobuf/stubs/status.h"
 #include "mixer/v1/attributes.pb.h"
+#include "quota/include/requirement.h"
+
+#include <vector>
 
 namespace istio {
 namespace mixer_control {
@@ -26,6 +29,8 @@ namespace mixer_control {
 struct RequestContext {
   // The attributes for both Check and Report.
   ::istio::mixer::v1::Attributes attributes;
+  // The quota requirements
+  std::vector<::istio::quota::Requirement> quotas;
   // The check status.
   ::google::protobuf::util::Status check_status;
 };

--- a/control/src/tcp/request_handler_impl.cc
+++ b/control/src/tcp/request_handler_impl.cc
@@ -43,9 +43,9 @@ CancelFunc RequestHandlerImpl::Check(CheckData* check_data, DoneFunc on_done) {
     return nullptr;
   }
 
-  std::vector<Requirement> quotas;
-  return client_context_->SendCheck(nullptr, on_done, quotas,
-                                    &request_context_);
+  client_context_->AddQuotas(&request_context_);
+
+  return client_context_->SendCheck(nullptr, on_done, &request_context_);
 }
 
 // Make remote report call.

--- a/quota/include/config_parser.h
+++ b/quota/include/config_parser.h
@@ -32,8 +32,8 @@ class ConfigParser {
   virtual ~ConfigParser() {}
 
   // Get quota requirements for a attribute set.
-  virtual std::vector<Requirement> GetRequirements(
-      const ::istio::mixer::v1::Attributes& attributes) const = 0;
+  virtual void GetRequirements(const ::istio::mixer::v1::Attributes& attributes,
+                               std::vector<Requirement>* results) const = 0;
 
   // The factory function to create a new instance of the parser.
   static std::unique_ptr<ConfigParser> Create(

--- a/quota/src/config_parser_impl.cc
+++ b/quota/src/config_parser_impl.cc
@@ -40,9 +40,8 @@ ConfigParserImpl::ConfigParserImpl(const QuotaSpec& spec_pb)
   }
 }
 
-std::vector<Requirement> ConfigParserImpl::GetRequirements(
-    const Attributes& attributes) const {
-  std::vector<Requirement> results;
+void ConfigParserImpl::GetRequirements(
+    const Attributes& attributes, std::vector<Requirement>* results) const {
   for (const auto& rule : spec_pb_.rules()) {
     bool matched = false;
     for (const auto& match : rule.match()) {
@@ -54,11 +53,10 @@ std::vector<Requirement> ConfigParserImpl::GetRequirements(
     // If not match, applies to all requests.
     if (matched || rule.match_size() == 0) {
       for (const auto& quota : rule.quotas()) {
-        results.push_back({quota.quota(), quota.charge()});
+        results->push_back({quota.quota(), quota.charge()});
       }
     }
   }
-  return results;
 }
 
 bool ConfigParserImpl::MatchAttributes(const AttributeMatch& match,

--- a/quota/src/config_parser_impl.h
+++ b/quota/src/config_parser_impl.h
@@ -31,8 +31,8 @@ class ConfigParserImpl : public ConfigParser {
       const ::istio::mixer::v1::config::client::QuotaSpec& spec_pb);
 
   // Get quota requirements for a attribute set.
-  std::vector<Requirement> GetRequirements(
-      const ::istio::mixer::v1::Attributes& attributes) const override;
+  void GetRequirements(const ::istio::mixer::v1::Attributes& attributes,
+                       std::vector<Requirement>* results) const override;
 
  private:
   // Check one attribute match.


### PR DESCRIPTION
* Use RequestContext to store quota vector
* Add cache map for ServiceContext so it can be used to preprocess config data.
* Change quota ConfigParser GetRequirements() function to not to return quota vector, instead pass its raw pointer as last argument so the data can be appended.