### PR TITLE
Add map_key caching support for string maps

### DIFF
--- a/src/check_cache.cc
+++ b/src/check_cache.cc
@@ -135,7 +135,7 @@ Status CheckCache::CacheResponse(const Attributes& attributes,
   }
 
   Referenced referenced;
-  if (!referenced.Fill(response.precondition().referenced_attributes())) {
+  if (!referenced.Fill(attributes, response.precondition().referenced_attributes())) {
     // Failed to decode referenced_attributes, not to cache this result.
     return ConvertRpcStatus(response.precondition().status());
   }

--- a/src/check_cache.cc
+++ b/src/check_cache.cc
@@ -26,7 +26,7 @@ namespace istio {
 namespace mixer_client {
 
 void CheckCache::CacheElem::CacheElem::SetResponse(
-    const CheckResponse& response, Tick time_now) {
+    const CheckResponse &response, Tick time_now) {
   if (response.has_precondition()) {
     status_ = parent_.ConvertRpcStatus(response.precondition().status());
 
@@ -63,7 +63,7 @@ bool CheckCache::CheckResult::IsCacheHit() const {
   return status_.error_code() != Code::UNAVAILABLE;
 }
 
-CheckCache::CheckCache(const CheckOptions& options) : options_(options) {
+CheckCache::CheckCache(const CheckOptions &options) : options_(options) {
   if (options.num_entries > 0) {
     cache_.reset(new CheckLRUCache(options.num_entries));
   }
@@ -74,15 +74,15 @@ CheckCache::~CheckCache() {
   FlushAll();
 }
 
-void CheckCache::Check(const Attributes& attributes, CheckResult* result) {
+void CheckCache::Check(const Attributes &attributes, CheckResult *result) {
   Status status = Check(attributes, system_clock::now());
   if (status.error_code() != Code::NOT_FOUND) {
     result->status_ = status;
   }
 
-  result->on_response_ = [this](const Status& status,
-                                const Attributes& attributes,
-                                const CheckResponse& response) -> Status {
+  result->on_response_ = [this](const Status &status,
+                                const Attributes &attributes,
+                                const CheckResponse &response) -> Status {
     if (!status.ok()) {
       if (options_.network_fail_open) {
         return Status::OK;
@@ -95,14 +95,14 @@ void CheckCache::Check(const Attributes& attributes, CheckResult* result) {
   };
 }
 
-Status CheckCache::Check(const Attributes& attributes, Tick time_now) {
+Status CheckCache::Check(const Attributes &attributes, Tick time_now) {
   if (!cache_) {
     // By returning NOT_FOUND, caller will send request to server.
     return Status(Code::NOT_FOUND, "");
   }
 
-  for (const auto& it : referenced_map_) {
-    const Referenced& reference = it.second;
+  for (const auto &it : referenced_map_) {
+    const Referenced &reference = it.second;
     std::string signature;
     if (!reference.Signature(attributes, "", &signature)) {
       continue;
@@ -111,7 +111,7 @@ Status CheckCache::Check(const Attributes& attributes, Tick time_now) {
     std::lock_guard<std::mutex> lock(cache_mutex_);
     CheckLRUCache::ScopedLookup lookup(cache_.get(), signature);
     if (lookup.Found()) {
-      CacheElem* elem = lookup.value();
+      CacheElem *elem = lookup.value();
       if (elem->IsExpired(time_now)) {
         cache_->Remove(signature);
         return Status(Code::NOT_FOUND, "");
@@ -123,8 +123,8 @@ Status CheckCache::Check(const Attributes& attributes, Tick time_now) {
   return Status(Code::NOT_FOUND, "");
 }
 
-Status CheckCache::CacheResponse(const Attributes& attributes,
-                                 const CheckResponse& response, Tick time_now) {
+Status CheckCache::CacheResponse(const Attributes &attributes,
+                                 const CheckResponse &response, Tick time_now) {
   if (!cache_ || !response.has_precondition()) {
     if (response.has_precondition()) {
       return ConvertRpcStatus(response.precondition().status());
@@ -135,7 +135,8 @@ Status CheckCache::CacheResponse(const Attributes& attributes,
   }
 
   Referenced referenced;
-  if (!referenced.Fill(attributes, response.precondition().referenced_attributes())) {
+  if (!referenced.Fill(attributes,
+                       response.precondition().referenced_attributes())) {
     // Failed to decode referenced_attributes, not to cache this result.
     return ConvertRpcStatus(response.precondition().status());
   }
@@ -161,7 +162,7 @@ Status CheckCache::CacheResponse(const Attributes& attributes,
     return lookup.value()->status();
   }
 
-  CacheElem* cache_elem = new CacheElem(*this, response, time_now);
+  CacheElem *cache_elem = new CacheElem(*this, response, time_now);
   cache_->Insert(signature, cache_elem, 1);
   return cache_elem->status();
 }
@@ -177,7 +178,7 @@ Status CheckCache::FlushAll() {
   return Status::OK;
 }
 
-Status CheckCache::ConvertRpcStatus(const ::google::rpc::Status& status) const {
+Status CheckCache::ConvertRpcStatus(const ::google::rpc::Status &status) const {
   // If server status code is INTERNAL, check network_fail_open flag.
   if (status.code() == Code::INTERNAL && options_.network_fail_open) {
     return Status::OK;

--- a/src/quota_cache.cc
+++ b/src/quota_cache.cc
@@ -209,7 +209,7 @@ void QuotaCache::SetResponse(const Attributes& attributes,
   }
 
   Referenced referenced;
-  if (!referenced.Fill(result->referenced_attributes())) {
+  if (!referenced.Fill(attributes, result->referenced_attributes())) {
     return;
   }
 

--- a/src/referenced.cc
+++ b/src/referenced.cc
@@ -16,7 +16,6 @@
 #include "referenced.h"
 
 #include "global_dictionary.h"
-#include "utils/md5.h"
 
 #include <algorithm>
 #include <map>
@@ -60,11 +59,13 @@ bool Decode(int idx, const std::vector<std::string> &global_words,
   return true;
 }
 
+}  // namespace
+
 // Updates hasher with keys
-void UpdateHash(const std::vector<Referenced::AttributeRef> &keys,
-                MD5 *hasher) {
+void Referenced::UpdateHash(const std::vector<AttributeRef> &keys,
+                            MD5 *hasher) {
   // keys are already sorted during Fill
-  for (const Referenced::AttributeRef &key : keys) {
+  for (const AttributeRef &key : keys) {
     hasher->Update(key.name);
     hasher->Update(kDelimiter, kDelimiterLength);
     if (!key.map_key.empty()) {
@@ -73,7 +74,7 @@ void UpdateHash(const std::vector<Referenced::AttributeRef> &keys,
     }
   }
 }
-}  // namespace
+
 bool Referenced::Fill(const Attributes &attributes,
                       const ReferencedAttributes &reference) {
   const std::vector<std::string> &global_words = GetGlobalWords();

--- a/src/referenced.h
+++ b/src/referenced.h
@@ -49,8 +49,10 @@ class Referenced {
  private:
   // The keys should be absence.
   std::vector<std::string> absence_keys_;
+  //std::vector<std::tuple<std::string, std::string>> absence_keys_;
   // The keys should match exactly.
   std::vector<std::string> exact_keys_;
+  //std::vector<std::tuple<std::string, std::string>> exact_keys_;
 };
 
 }  // namespace mixer_client

--- a/src/referenced.h
+++ b/src/referenced.h
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "mixer/v1/check.pb.h"
+#include "utils/md5.h"
 
 namespace istio {
 namespace mixer_client {
@@ -47,6 +48,7 @@ class Referenced {
   // For debug logging only.
   std::string DebugString() const;
 
+ private:
   // Holds reference to an attribute and potentially a map key
   struct AttributeRef {
     // name of the attribute
@@ -65,11 +67,14 @@ class Referenced {
     };
   };
 
- private:
   // The keys should be absence.
   std::vector<AttributeRef> absence_keys_;
+
   // The keys should match exactly.
   std::vector<AttributeRef> exact_keys_;
+
+  // Updates hasher with keys
+  static void UpdateHash(const std::vector<AttributeRef> &keys, MD5 *hasher);
 };
 
 }  // namespace mixer_client

--- a/src/referenced.h
+++ b/src/referenced.h
@@ -30,17 +30,15 @@ struct AttributeRef {
   // only used if attribute is a stringMap
   std::string map_key;
 
-  bool operator<(const AttributeRef& b)
-  {
+  bool operator<(const AttributeRef &b) {
     int cmp = name.compare(b.name);
-    if (cmp == 0){
+    if (cmp == 0) {
       return map_key.compare(b.map_key) < 0;
     }
 
     return cmp < 0;
   };
 };
-
 
 // The object to store referenced attributes used by Mixer server.
 // Mixer client cache should only use referenced attributes
@@ -50,15 +48,15 @@ class Referenced {
   // Fill the object from the protobuf from Check response.
   // Return false if any attribute names could not be decoded from client
   // global dictionary.
-  bool Fill(const ::istio::mixer::v1::Attributes& attributes,
-            const ::istio::mixer::v1::ReferencedAttributes& reference);
+  bool Fill(const ::istio::mixer::v1::Attributes &attributes,
+            const ::istio::mixer::v1::ReferencedAttributes &reference);
 
   // Calculate a cache signature for the attributes.
   // Return false if attributes are mismatched, such as "absence" attributes
   // present
   // or "exact" match attributes don't present.
-  bool Signature(const ::istio::mixer::v1::Attributes& attributes,
-                 const std::string& extra_key, std::string* signature) const;
+  bool Signature(const ::istio::mixer::v1::Attributes &attributes,
+                 const std::string &extra_key, std::string *signature) const;
 
   // A hash value to identify an instance.
   std::string Hash() const;

--- a/src/referenced.h
+++ b/src/referenced.h
@@ -23,23 +23,6 @@
 namespace istio {
 namespace mixer_client {
 
-// Holds reference to an attribute and potentially a map key
-struct AttributeRef {
-  // name of the attribute
-  std::string name;
-  // only used if attribute is a stringMap
-  std::string map_key;
-
-  bool operator<(const AttributeRef &b) {
-    int cmp = name.compare(b.name);
-    if (cmp == 0) {
-      return map_key.compare(b.map_key) < 0;
-    }
-
-    return cmp < 0;
-  };
-};
-
 // The object to store referenced attributes used by Mixer server.
 // Mixer client cache should only use referenced attributes
 // in its cache (for both Check cache and quota cache).
@@ -63,6 +46,24 @@ class Referenced {
 
   // For debug logging only.
   std::string DebugString() const;
+
+  // Holds reference to an attribute and potentially a map key
+  struct AttributeRef {
+    // name of the attribute
+    std::string name;
+    // only used if attribute is a stringMap
+    std::string map_key;
+
+    // make vector<AttributeRef> sortable
+    bool operator<(const AttributeRef &b) {
+      int cmp = name.compare(b.name);
+      if (cmp == 0) {
+        return map_key.compare(b.map_key) < 0;
+      }
+
+      return cmp < 0;
+    };
+  };
 
  private:
   // The keys should be absence.

--- a/src/referenced.h
+++ b/src/referenced.h
@@ -23,6 +23,25 @@
 namespace istio {
 namespace mixer_client {
 
+// Holds reference to an attribute and potentially a map key
+struct AttributeRef {
+  // name of the attribute
+  std::string name;
+  // only used if attribute is a stringMap
+  std::string map_key;
+
+  bool operator<(const AttributeRef& b)
+  {
+    int cmp = name.compare(b.name);
+    if (cmp == 0){
+      return map_key.compare(b.map_key) < 0;
+    }
+
+    return cmp < 0;
+  };
+};
+
+
 // The object to store referenced attributes used by Mixer server.
 // Mixer client cache should only use referenced attributes
 // in its cache (for both Check cache and quota cache).
@@ -31,7 +50,8 @@ class Referenced {
   // Fill the object from the protobuf from Check response.
   // Return false if any attribute names could not be decoded from client
   // global dictionary.
-  bool Fill(const ::istio::mixer::v1::ReferencedAttributes& reference);
+  bool Fill(const ::istio::mixer::v1::Attributes& attributes,
+            const ::istio::mixer::v1::ReferencedAttributes& reference);
 
   // Calculate a cache signature for the attributes.
   // Return false if attributes are mismatched, such as "absence" attributes
@@ -48,11 +68,9 @@ class Referenced {
 
  private:
   // The keys should be absence.
-  std::vector<std::string> absence_keys_;
-  //std::vector<std::tuple<std::string, std::string>> absence_keys_;
+  std::vector<AttributeRef> absence_keys_;
   // The keys should match exactly.
-  std::vector<std::string> exact_keys_;
-  //std::vector<std::tuple<std::string, std::string>> exact_keys_;
+  std::vector<AttributeRef> exact_keys_;
 };
 
 }  // namespace mixer_client

--- a/src/referenced_test.cc
+++ b/src/referenced_test.cc
@@ -37,6 +37,8 @@ words: "int-key"
 words: "time-key"
 words: "duration-key"
 words: "string-map-key"
+words: "User-Agent"
+words: "If-Match"
 attribute_matches {
   name: 9,
   condition: ABSENCE,
@@ -75,7 +77,31 @@ attribute_matches {
 }
 attribute_matches {
   name: -8,
+  map_key: -10,
   condition: EXACT,
+}
+attribute_matches {
+  name: -8,
+  map_key: -9,
+  condition: ABSENCE,
+}
+)";
+
+const char kAttributesText[] = R"(
+attributes {
+   key: "string-map-key"
+   value {
+     string_map_value {
+       entries {
+         key: "User-Agent"
+         value: "chrome60"
+       }
+       entries {
+         key: "path"
+         value: "/books"
+       }
+     }
+   }
 }
 )";
 
@@ -101,39 +127,45 @@ TEST(ReferencedTest, FillSuccessTest) {
   ::istio::mixer::v1::ReferencedAttributes pb;
   ASSERT_TRUE(TextFormat::ParseFromString(kReferencedText, &pb));
 
+  ::istio::mixer::v1::Attributes attrs;
+  ASSERT_TRUE(TextFormat::ParseFromString(kAttributesText, &attrs));
+
+
   Referenced referenced;
-  EXPECT_TRUE(referenced.Fill(pb));
+  EXPECT_TRUE(referenced.Fill(attrs, pb));
 
   EXPECT_EQ(referenced.DebugString(),
-            "Absence-keys: target.service, target.name, Exact-keys: bool-key, "
-            "bytes-key, string-key, double-key, int-key, time-key, "
-            "duration-key, string-map-key, ");
+            "Absence-keys: string-map-key[User-Agent], target.name, target.service, Exact-keys: bool-key, bytes-key, double-key, duration-key, int-key, string-key, string-map-key[If-Match], time-key, ");
 
   EXPECT_EQ(MD5::DebugString(referenced.Hash()),
-            "e8066212fef8b8a2fde6daf0f7974d01");
+            "602d5bbd45b623c3560d2bdb6104f3ab");
 }
 
 TEST(ReferencedTest, FillFail1Test) {
   ::istio::mixer::v1::ReferencedAttributes pb;
   ASSERT_TRUE(TextFormat::ParseFromString(kReferencedFailText1, &pb));
 
+  ::istio::mixer::v1::Attributes attrs;
   Referenced referenced;
-  EXPECT_FALSE(referenced.Fill(pb));
+  EXPECT_FALSE(referenced.Fill(attrs, pb));
 }
 
 TEST(ReferencedTest, FillFail2Test) {
   ::istio::mixer::v1::ReferencedAttributes pb;
   ASSERT_TRUE(TextFormat::ParseFromString(kReferencedFailText2, &pb));
+  ::istio::mixer::v1::Attributes attrs;
 
   Referenced referenced;
-  EXPECT_FALSE(referenced.Fill(pb));
+  EXPECT_FALSE(referenced.Fill(attrs, pb));
 }
 
 TEST(ReferencedTest, NegativeSignature1Test) {
   ::istio::mixer::v1::ReferencedAttributes pb;
   ASSERT_TRUE(TextFormat::ParseFromString(kReferencedText, &pb));
+  ::istio::mixer::v1::Attributes attrs;
+  ASSERT_TRUE(TextFormat::ParseFromString(kAttributesText, &attrs));
   Referenced referenced;
-  EXPECT_TRUE(referenced.Fill(pb));
+  EXPECT_TRUE(referenced.Fill(attrs, pb));
 
   std::string signature;
 
@@ -151,8 +183,6 @@ TEST(ReferencedTest, NegativeSignature1Test) {
 TEST(ReferencedTest, OKSignature1Test) {
   ::istio::mixer::v1::ReferencedAttributes pb;
   ASSERT_TRUE(TextFormat::ParseFromString(kReferencedText, &pb));
-  Referenced referenced;
-  EXPECT_TRUE(referenced.Fill(pb));
 
   Attributes attributes;
   AttributesBuilder builder(&attributes);
@@ -169,14 +199,17 @@ TEST(ReferencedTest, OKSignature1Test) {
       "duration-key",
       std::chrono::duration_cast<std::chrono::nanoseconds>(secs));
 
-  std::map<std::string, std::string> string_map = {{"key1", "value1"},
+  std::map<std::string, std::string> string_map = {{"If-Match", "value1"},
                                                    {"key2", "value2"}};
   builder.AddStringMap("string-map-key", std::move(string_map));
+
+  Referenced referenced;
+  EXPECT_TRUE(referenced.Fill(attributes, pb));
 
   std::string signature;
   EXPECT_TRUE(referenced.Signature(attributes, "extra", &signature));
 
-  EXPECT_EQ(MD5::DebugString(signature), "cd3ee7fbe836b973f84f5075ef4ac29d");
+  EXPECT_EQ(MD5::DebugString(signature), "751b028b2e2c230ef9c4e59ac556ca04");
 }
 
 }  // namespace

--- a/src/referenced_test.cc
+++ b/src/referenced_test.cc
@@ -130,12 +130,14 @@ TEST(ReferencedTest, FillSuccessTest) {
   ::istio::mixer::v1::Attributes attrs;
   ASSERT_TRUE(TextFormat::ParseFromString(kAttributesText, &attrs));
 
-
   Referenced referenced;
   EXPECT_TRUE(referenced.Fill(attrs, pb));
 
   EXPECT_EQ(referenced.DebugString(),
-            "Absence-keys: string-map-key[User-Agent], target.name, target.service, Exact-keys: bool-key, bytes-key, double-key, duration-key, int-key, string-key, string-map-key[If-Match], time-key, ");
+            "Absence-keys: string-map-key[User-Agent], target.name, "
+            "target.service, Exact-keys: bool-key, bytes-key, double-key, "
+            "duration-key, int-key, string-key, string-map-key[If-Match], "
+            "time-key, ");
 
   EXPECT_EQ(MD5::DebugString(referenced.Hash()),
             "602d5bbd45b623c3560d2bdb6104f3ab");


### PR DESCRIPTION
1. Add map_key caching support for string maps
2. Refactor decode into common code.
3. Introduce AttributeRef for name and map_key