### PR TITLE
Support empty service_configs.

### DIFF
--- a/control/src/http/client_context.cc
+++ b/control/src/http/client_context.cc
@@ -53,13 +53,14 @@ const std::string& ClientContext::GetServiceName(
 }
 
 // Get the service config by the name.
-const ServiceConfig& ClientContext::GetServiceConfig(
+const ServiceConfig* ClientContext::GetServiceConfig(
     const std::string& service_name) const {
   const auto& config_map = config_.service_configs();
   auto it = config_map.find(service_name);
-  // The name should be a valid one checked by GetServiceName()
-  GOOGLE_CHECK(it != config_map.end());
-  return it->second;
+  if (it != config_map.end()) {
+    return &it->second;
+  }
+  return nullptr;
 }
 
 }  // namespace http

--- a/control/src/http/client_context.h
+++ b/control/src/http/client_context.h
@@ -49,7 +49,7 @@ class ClientContext : public ClientContextBase {
   const std::string& GetServiceName(const std::string& service_name) const;
 
   // Get the service config by the name.
-  const ::istio::mixer::v1::config::client::ServiceConfig& GetServiceConfig(
+  const ::istio::mixer::v1::config::client::ServiceConfig* GetServiceConfig(
       const std::string& service_name) const;
 
  private:

--- a/control/src/http/controller_impl.cc
+++ b/control/src/http/controller_impl.cc
@@ -37,7 +37,7 @@ std::shared_ptr<ServiceContext> ControllerImpl::GetServiceContext(
   // If use legacy config
   if (config.legacy_config) {
     return std::make_shared<ServiceContext>(client_context_,
-                                            *config.legacy_config);
+                                            config.legacy_config);
   }
 
   const std::string& origin_name = config.destination_service;
@@ -45,13 +45,17 @@ std::shared_ptr<ServiceContext> ControllerImpl::GetServiceContext(
   if (!service_context) {
     // Get the valid service name from service_configs map.
     auto valid_name = client_context_->GetServiceName(origin_name);
-    service_context = service_context_map_[valid_name];
+    if (valid_name != origin_name) {
+      service_context = service_context_map_[valid_name];
+    }
     if (!service_context) {
       service_context = std::make_shared<ServiceContext>(
           client_context_, client_context_->GetServiceConfig(valid_name));
       service_context_map_[valid_name] = service_context;
     }
-    service_context_map_[origin_name] = service_context;
+    if (valid_name != origin_name) {
+      service_context_map_[origin_name] = service_context;
+    }
   }
   return service_context;
 }

--- a/control/src/http/service_context.h
+++ b/control/src/http/service_context.h
@@ -31,7 +31,7 @@ class ServiceContext {
  public:
   ServiceContext(
       std::shared_ptr<ClientContext> client_context,
-      const ::istio::mixer::v1::config::client::ServiceConfig& config);
+      const ::istio::mixer::v1::config::client::ServiceConfig* config);
 
   std::shared_ptr<ClientContext> client_context() const {
     return client_context_;
@@ -47,13 +47,16 @@ class ServiceContext {
   void AddQuotas(RequestContext* request) const;
 
   bool enable_mixer_check() const {
-    return !service_config_.disable_check_calls();
+    return service_config_ && !service_config_->disable_check_calls();
   }
   bool enable_mixer_report() const {
-    return !service_config_.disable_report_calls();
+    return service_config_ && !service_config_->disable_report_calls();
   }
 
  private:
+  // Pre-process the config data to build parser objects.
+  void BuildParsers();
+
   // The client context object.
   std::shared_ptr<ClientContext> client_context_;
 
@@ -66,7 +69,7 @@ class ServiceContext {
   std::vector<std::unique_ptr<::istio::quota::ConfigParser>> quota_parsers_;
 
   // The service config.
-  ::istio::mixer::v1::config::client::ServiceConfig service_config_;
+  const ::istio::mixer::v1::config::client::ServiceConfig* service_config_{};
 };
 
 }  // namespace http


### PR DESCRIPTION
If a mixer filter is only used for forwarding attributes,  it may not have service_configs map.
```release-note
NONE
```