### PR TITLE
Fixed a test failure issue.

### DIFF
--- a/control/src/http/service_context.cc
+++ b/control/src/http/service_context.cc
@@ -24,7 +24,10 @@ namespace http {
 
 ServiceContext::ServiceContext(std::shared_ptr<ClientContext> client_context,
                                const ServiceConfig* config)
-    : client_context_(client_context), service_config_(config) {
+    : client_context_(client_context) {
+  if (config) {
+    service_config_.reset(new ServiceConfig(*config));
+  }
   BuildParsers();
 }
 

--- a/control/src/http/service_context.h
+++ b/control/src/http/service_context.h
@@ -69,7 +69,8 @@ class ServiceContext {
   std::vector<std::unique_ptr<::istio::quota::ConfigParser>> quota_parsers_;
 
   // The service config.
-  const ::istio::mixer::v1::config::client::ServiceConfig* service_config_{};
+  std::unique_ptr<::istio::mixer::v1::config::client::ServiceConfig>
+      service_config_;
 };
 
 }  // namespace http


### PR DESCRIPTION
service config should be stored in service_context.  Should not use the pointer since the object life time could not be controlled. 

```release-note
NONE
```