### PR TITLE
Support mixerclient to generate authentication attributes

### DIFF
--- a/control/include/http/check_data.h
+++ b/control/include/http/check_data.h
@@ -76,8 +76,8 @@ class CheckData {
   virtual bool FindCookie(const std::string &name,
                           std::string *value) const = 0;
 
-  // Extracts authentication information from header. Returns true on success,
-  // and saves authentication information in |payload|. Returns false otherwise.
+  // If the request has a JWT token and it is verified, get its payload as
+  // string map, and return true. Otherwise return false.
   virtual bool GetJWTPayload(
       std::map<std::string, std::string> *payload) const = 0;
 };

--- a/control/include/http/check_data.h
+++ b/control/include/http/check_data.h
@@ -32,16 +32,16 @@ class CheckData {
   // Find "x-istio-attributes" HTTP header.
   // If found, base64 decode its value,  pass it out
   // and remove the HTTP header from the request.
-  virtual bool ExtractIstioAttributes(std::string* data) = 0;
+  virtual bool ExtractIstioAttributes(std::string *data) = 0;
 
   // Base64 encode data, and add it as "x-istio-attributes" HTTP header.
-  virtual void AddIstioAttributes(const std::string& data) = 0;
+  virtual void AddIstioAttributes(const std::string &data) = 0;
 
   // Get downstream tcp connection ip and port.
-  virtual bool GetSourceIpPort(std::string* ip, int* port) const = 0;
+  virtual bool GetSourceIpPort(std::string *ip, int *port) const = 0;
 
   // If SSL is used, get origin user name.
-  virtual bool GetSourceUser(std::string* user) const = 0;
+  virtual bool GetSourceUser(std::string *user) const = 0;
 
   // Get request HTTP headers
   virtual std::map<std::string, std::string> GetRequestHeaders() const = 0;
@@ -60,26 +60,26 @@ class CheckData {
     HEADER_REFERER,
   };
   virtual bool FindHeaderByType(HeaderType header_type,
-                                std::string* value) const = 0;
+                                std::string *value) const = 0;
 
   // A generic way to find any HTTP header.
   // This is for custom HTTP headers, such as x-api-key
   // Envoy platform requires "name" to be lower_case.
-  virtual bool FindHeaderByName(const std::string& name,
-                                std::string* value) const = 0;
+  virtual bool FindHeaderByName(const std::string &name,
+                                std::string *value) const = 0;
 
   // Find query parameter by name.
-  virtual bool FindQueryParameter(const std::string& name,
-                                  std::string* value) const = 0;
+  virtual bool FindQueryParameter(const std::string &name,
+                                  std::string *value) const = 0;
 
   // Find Cookie header.
-  virtual bool FindCookie(const std::string& name,
-                          std::string* value) const = 0;
+  virtual bool FindCookie(const std::string &name,
+                          std::string *value) const = 0;
 
   // Extracts authentication information from header. Returns true on success,
   // and saves authentication information in |attrs|. Returns false otherwise.
   virtual bool GetAuthenticationHeader(
-    std::map<std::string, std::string>* attrs) const = 0;
+      std::map<std::string, std::string> *attrs) const = 0;
 };
 
 }  // namespace http

--- a/control/include/http/check_data.h
+++ b/control/include/http/check_data.h
@@ -77,9 +77,9 @@ class CheckData {
                           std::string *value) const = 0;
 
   // Extracts authentication information from header. Returns true on success,
-  // and saves authentication information in |attrs|. Returns false otherwise.
-  virtual bool GetAuthenticationHeader(
-      std::map<std::string, std::string> *attrs) const = 0;
+  // and saves authentication information in |payload|. Returns false otherwise.
+  virtual bool GetJWTPayload(
+      std::map<std::string, std::string> *payload) const = 0;
 };
 
 }  // namespace http

--- a/control/include/http/check_data.h
+++ b/control/include/http/check_data.h
@@ -75,6 +75,11 @@ class CheckData {
   // Find Cookie header.
   virtual bool FindCookie(const std::string& name,
                           std::string* value) const = 0;
+
+  // Extracts authentication information from header. Returns true on success,
+  // and saves authentication information in |attrs|. Returns false otherwise.
+  virtual bool GetAuthenticationHeader(
+    std::map<std::string, std::string>* attrs) const = 0;
 };
 
 }  // namespace http

--- a/control/src/attribute_names.cc
+++ b/control/src/attribute_names.cc
@@ -61,5 +61,11 @@ const char AttributeName::kContextTime[] = "context.time";
 // Check status code.
 const char AttributeName::kCheckStatusCode[] = "check.status";
 
+// Authentication attributes
+const char AttributeName::kRequestAuthPrincipal[] = "request.auth.principal";
+const char AttributeName::kRequestAuthAudiences[] = "request.auth.audiences";
+const char AttributeName::kRequestAuthPresenter[] = "request.auth.presenter";
+const char AttributeName::kRequestAuthClaims[] = "request.auth.claims";
+
 }  // namespace mixer_control
 }  // namespace istio

--- a/control/src/attribute_names.h
+++ b/control/src/attribute_names.h
@@ -62,6 +62,12 @@ struct AttributeName {
 
   // Check status code.
   static const char kCheckStatusCode[];
+
+  // Authentication attributes
+  static const char kRequestAuthPrincipal[];
+  static const char kRequestAuthAudiences[];
+  static const char kRequestAuthPresenter[];
+  static const char kRequestAuthClaims[];
 };
 
 }  // namespace mixer_control

--- a/control/src/http/attributes_builder.cc
+++ b/control/src/http/attributes_builder.cc
@@ -149,6 +149,6 @@ void AttributesBuilder::ExtractReportAttributes(ReportData *report_data) {
   }
 }
 
-} // namespace http
-} // namespace mixer_control
-} // namespace istio
+}  // namespace http
+}  // namespace mixer_control
+}  // namespace istio

--- a/control/src/http/attributes_builder.cc
+++ b/control/src/http/attributes_builder.cc
@@ -26,16 +26,16 @@ namespace istio {
 namespace mixer_control {
 namespace http {
 
-void AttributesBuilder::ExtractRequestHeaderAttributes(CheckData* check_data) {
+void AttributesBuilder::ExtractRequestHeaderAttributes(CheckData *check_data) {
   ::istio::mixer_client::AttributesBuilder builder(&request_->attributes);
   std::map<std::string, std::string> headers = check_data->GetRequestHeaders();
   builder.AddStringMap(AttributeName::kRequestHeaders, headers);
 
   struct TopLevelAttr {
     CheckData::HeaderType header_type;
-    const std::string& name;
+    const std::string &name;
     bool set_default;
-    const char* default_value;
+    const char *default_value;
   };
   static TopLevelAttr attrs[] = {
       {CheckData::HEADER_HOST, AttributeName::kRequestHost, true, ""},
@@ -47,7 +47,7 @@ void AttributesBuilder::ExtractRequestHeaderAttributes(CheckData* check_data) {
        ""},
   };
 
-  for (const auto& it : attrs) {
+  for (const auto &it : attrs) {
     std::string data;
     if (check_data->FindHeaderByType(it.header_type, &data)) {
       builder.AddString(it.name, data);
@@ -57,14 +57,14 @@ void AttributesBuilder::ExtractRequestHeaderAttributes(CheckData* check_data) {
   }
 }
 
-void AttributesBuilder::ExtractRequestAuthAttributes(CheckData* check_data) {
+void AttributesBuilder::ExtractRequestAuthAttributes(CheckData *check_data) {
   std::map<std::string, std::string> attrs;
   if (check_data->GetAuthenticationHeader(&attrs) && !attrs.empty()) {
     // Populate auth attributes.
     ::istio::mixer_client::AttributesBuilder builder(&request_->attributes);
     if (attrs.count("iss") > 0 && attrs.count("sub") > 0) {
       builder.AddString(AttributeName::kRequestAuthPrincipal,
-        attrs["iss"] + "/" + attrs["sub"]);
+                        attrs["iss"] + "/" + attrs["sub"]);
     }
     if (attrs.count("aud") > 0) {
       builder.AddString(AttributeName::kRequestAuthAudiences, attrs["aud"]);
@@ -76,7 +76,7 @@ void AttributesBuilder::ExtractRequestAuthAttributes(CheckData* check_data) {
   }
 }
 
-void AttributesBuilder::ExtractForwardedAttributes(CheckData* check_data) {
+void AttributesBuilder::ExtractForwardedAttributes(CheckData *check_data) {
   std::string forwarded_data;
   if (!check_data->ExtractIstioAttributes(&forwarded_data)) {
     return;
@@ -91,13 +91,13 @@ void AttributesBuilder::ExtractForwardedAttributes(CheckData* check_data) {
   Attributes_StringMap forwarded_attributes;
   if (forwarded_attributes.ParseFromString(forwarded_data)) {
     ::istio::mixer_client::AttributesBuilder builder(&request_->attributes);
-    for (const auto& it : forwarded_attributes.entries()) {
+    for (const auto &it : forwarded_attributes.entries()) {
       builder.AddIpOrString(it.first, it.second);
     }
   }
 }
 
-void AttributesBuilder::ExtractCheckAttributes(CheckData* check_data) {
+void AttributesBuilder::ExtractCheckAttributes(CheckData *check_data) {
   ExtractRequestHeaderAttributes(check_data);
   ExtractRequestAuthAttributes(check_data);
 
@@ -119,14 +119,14 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData* check_data) {
   builder.AddString(AttributeName::kContextProtocol, "http");
 }
 
-void AttributesBuilder::ForwardAttributes(const Attributes& forward_attributes,
-                                          CheckData* check_data) {
+void AttributesBuilder::ForwardAttributes(const Attributes &forward_attributes,
+                                          CheckData *check_data) {
   std::string str;
   forward_attributes.SerializeToString(&str);
   check_data->AddIstioAttributes(str);
 }
 
-void AttributesBuilder::ExtractReportAttributes(ReportData* report_data) {
+void AttributesBuilder::ExtractReportAttributes(ReportData *report_data) {
   ::istio::mixer_client::AttributesBuilder builder(&request_->attributes);
   std::map<std::string, std::string> headers =
       report_data->GetResponseHeaders();
@@ -149,6 +149,6 @@ void AttributesBuilder::ExtractReportAttributes(ReportData* report_data) {
   }
 }
 
-}  // namespace http
-}  // namespace mixer_control
-}  // namespace istio
+} // namespace http
+} // namespace mixer_control
+} // namespace istio

--- a/control/src/http/attributes_builder.cc
+++ b/control/src/http/attributes_builder.cc
@@ -58,21 +58,21 @@ void AttributesBuilder::ExtractRequestHeaderAttributes(CheckData *check_data) {
 }
 
 void AttributesBuilder::ExtractRequestAuthAttributes(CheckData *check_data) {
-  std::map<std::string, std::string> attrs;
-  if (check_data->GetAuthenticationHeader(&attrs) && !attrs.empty()) {
+  std::map<std::string, std::string> payload;
+  if (check_data->GetJWTPayload(&payload) && !payload.empty()) {
     // Populate auth attributes.
     ::istio::mixer_client::AttributesBuilder builder(&request_->attributes);
-    if (attrs.count("iss") > 0 && attrs.count("sub") > 0) {
+    if (payload.count("iss") > 0 && payload.count("sub") > 0) {
       builder.AddString(AttributeName::kRequestAuthPrincipal,
-                        attrs["iss"] + "/" + attrs["sub"]);
+                        payload["iss"] + "/" + payload["sub"]);
     }
-    if (attrs.count("aud") > 0) {
-      builder.AddString(AttributeName::kRequestAuthAudiences, attrs["aud"]);
+    if (payload.count("aud") > 0) {
+      builder.AddString(AttributeName::kRequestAuthAudiences, payload["aud"]);
     }
-    if (attrs.count("azp") > 0) {
-      builder.AddString(AttributeName::kRequestAuthPresenter, attrs["azp"]);
+    if (payload.count("azp") > 0) {
+      builder.AddString(AttributeName::kRequestAuthPresenter, payload["azp"]);
     }
-    builder.AddStringMap(AttributeName::kRequestAuthClaims, attrs);
+    builder.AddStringMap(AttributeName::kRequestAuthClaims, payload);
   }
 }
 

--- a/control/src/http/attributes_builder.h
+++ b/control/src/http/attributes_builder.h
@@ -43,6 +43,9 @@ class AttributesBuilder {
  private:
   // Extract HTTP header attributes
   void ExtractRequestHeaderAttributes(CheckData* check_data);
+  // Extract authentication attributes for Check call.
+  void ExtractRequestAuthAttributes(CheckData* check_data);
+
   // The request context object.
   RequestContext* request_;
 };

--- a/control/src/http/attributes_builder_test.cc
+++ b/control/src/http/attributes_builder_test.cc
@@ -207,7 +207,7 @@ attributes {
 }
 )";
 
-void ClearContextTime(const std::string& name, RequestContext* request) {
+void ClearContextTime(const std::string &name, RequestContext *request) {
   // Override timestamp with -
   ::istio::mixer_client::AttributesBuilder builder(&request->attributes);
   std::chrono::time_point<std::chrono::system_clock> time0;
@@ -217,7 +217,7 @@ void ClearContextTime(const std::string& name, RequestContext* request) {
 TEST(AttributesBuilderTest, TestExtractV1ForwardedAttributes) {
   ::testing::NiceMock<MockCheckData> mock_data;
   EXPECT_CALL(mock_data, ExtractIstioAttributes(_))
-      .WillOnce(Invoke([](std::string* data) -> bool {
+      .WillOnce(Invoke([](std::string *data) -> bool {
         // v1 format
         Attributes_StringMap attr_map;
         (*attr_map.mutable_entries())["test_key"] = "test_value";
@@ -240,7 +240,7 @@ TEST(AttributesBuilderTest, TestExtractV2ForwardedAttributes) {
 
   ::testing::NiceMock<MockCheckData> mock_data;
   EXPECT_CALL(mock_data, ExtractIstioAttributes(_))
-      .WillOnce(Invoke([&attr](std::string* data) -> bool {
+      .WillOnce(Invoke([&attr](std::string *data) -> bool {
         attr.SerializeToString(data);
         return true;
       }));
@@ -255,7 +255,7 @@ TEST(AttributesBuilderTest, TestForwardAttributes) {
   Attributes forwarded_attr;
   ::testing::NiceMock<MockCheckData> mock_data;
   EXPECT_CALL(mock_data, AddIstioAttributes(_))
-      .WillOnce(Invoke([&forwarded_attr](const std::string& data) {
+      .WillOnce(Invoke([&forwarded_attr](const std::string &data) {
         EXPECT_TRUE(forwarded_attr.ParseFromString(data));
       }));
 
@@ -270,13 +270,13 @@ TEST(AttributesBuilderTest, TestForwardAttributes) {
 TEST(AttributesBuilderTest, TestCheckAttributes) {
   ::testing::NiceMock<MockCheckData> mock_data;
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _))
-      .WillOnce(Invoke([](std::string* ip, int* port) -> bool {
+      .WillOnce(Invoke([](std::string *ip, int *port) -> bool {
         *ip = "1.2.3.4";
         *port = 8080;
         return true;
       }));
   EXPECT_CALL(mock_data, GetSourceUser(_))
-      .WillOnce(Invoke([](std::string* user) -> bool {
+      .WillOnce(Invoke([](std::string *user) -> bool {
         *user = "test_user";
         return true;
       }));
@@ -289,7 +289,7 @@ TEST(AttributesBuilderTest, TestCheckAttributes) {
       }));
   EXPECT_CALL(mock_data, FindHeaderByType(_, _))
       .WillRepeatedly(Invoke(
-          [](CheckData::HeaderType header_type, std::string* value) -> bool {
+          [](CheckData::HeaderType header_type, std::string *value) -> bool {
             if (header_type == CheckData::HEADER_PATH) {
               *value = "/books";
               return true;
@@ -299,15 +299,15 @@ TEST(AttributesBuilderTest, TestCheckAttributes) {
             }
             return false;
           }));
-  EXPECT_CALL(mock_data, GetAuthenticationHeader(_))
-      .WillOnce(Invoke([](std::map<std::string, std::string>* attrs) -> bool {
-        (*attrs)["iss"] = "thisisiss";
-        (*attrs)["sub"] = "thisissub";
-        (*attrs)["aud"] = "thisisaud";
-        (*attrs)["azp"] = "thisisazp";
-        (*attrs)["email"] = "thisisemail@email.com";
-        (*attrs)["iat"] = "1512754205";
-        (*attrs)["exp"] = "5112754205";
+  EXPECT_CALL(mock_data, GetJWTPayload(_))
+      .WillOnce(Invoke([](std::map<std::string, std::string> *payload) -> bool {
+        (*payload)["iss"] = "thisisiss";
+        (*payload)["sub"] = "thisissub";
+        (*payload)["aud"] = "thisisaud";
+        (*payload)["azp"] = "thisisazp";
+        (*payload)["email"] = "thisisemail@email.com";
+        (*payload)["iat"] = "1512754205";
+        (*payload)["exp"] = "5112754205";
         return true;
       }));
 
@@ -338,7 +338,7 @@ TEST(AttributesBuilderTest, TestReportAttributes) {
         return map;
       }));
   EXPECT_CALL(mock_data, GetReportInfo(_))
-      .WillOnce(Invoke([](ReportData::ReportInfo* info) {
+      .WillOnce(Invoke([](ReportData::ReportInfo *info) {
         info->received_bytes = 100;
         info->send_bytes = 200;
         info->duration = std::chrono::nanoseconds(1);

--- a/control/src/http/attributes_builder_test.cc
+++ b/control/src/http/attributes_builder_test.cc
@@ -101,6 +101,59 @@ attributes {
     string_value: "test_user"
   }
 }
+attributes {
+  key: "request.auth.audiences"
+  value {
+    string_value: "thisisaud"
+  }
+}
+attributes {
+  key: "request.auth.claims"
+  value {
+    string_map_value {
+      entries {
+        key: "aud"
+        value: "thisisaud"
+      }
+      entries {
+        key: "azp"
+        value: "thisisazp"
+      }
+      entries {
+        key: "email"
+        value: "thisisemail@email.com"
+      }
+      entries {
+        key: "exp"
+        value: "5112754205"
+      }
+      entries {
+        key: "iat"
+        value: "1512754205"
+      }
+      entries {
+        key: "iss"
+        value: "thisisiss"
+      }
+      entries {
+        key: "sub"
+        value: "thisissub"
+      }
+    }
+  }
+}
+attributes {
+  key: "request.auth.presenter"
+  value {
+    string_value: "thisisazp"
+  }
+}
+attributes {
+  key: "request.auth.principal"
+  value {
+    string_value: "thisisiss/thisissub"
+  }
+}
 )";
 
 const char kReportAttributes[] = R"(
@@ -246,6 +299,17 @@ TEST(AttributesBuilderTest, TestCheckAttributes) {
             }
             return false;
           }));
+  EXPECT_CALL(mock_data, GetAuthenticationHeader(_))
+      .WillOnce(Invoke([](std::map<std::string, std::string>* attrs) -> bool {
+        (*attrs)["iss"] = "thisisiss";
+        (*attrs)["sub"] = "thisissub";
+        (*attrs)["aud"] = "thisisaud";
+        (*attrs)["azp"] = "thisisazp";
+        (*attrs)["email"] = "thisisemail@email.com";
+        (*attrs)["iat"] = "1512754205";
+        (*attrs)["exp"] = "5112754205";
+        return true;
+      }));
 
   RequestContext request;
   AttributesBuilder builder(&request);

--- a/control/src/http/mock_check_data.h
+++ b/control/src/http/mock_check_data.h
@@ -40,6 +40,8 @@ class MockCheckData : public CheckData {
                      bool(const std::string& name, std::string* value));
   MOCK_CONST_METHOD2(FindCookie,
                      bool(const std::string& name, std::string* value));
+  MOCK_CONST_METHOD1(GetAuthenticationHeader,
+                     bool(std::map<std::string, std::string>* attrs));
 };
 
 }  // namespace http

--- a/control/src/http/mock_check_data.h
+++ b/control/src/http/mock_check_data.h
@@ -26,22 +26,22 @@ namespace http {
 // The mock object for CheckData interface.
 class MockCheckData : public CheckData {
  public:
-  MOCK_METHOD1(ExtractIstioAttributes, bool(std::string* data));
-  MOCK_METHOD1(AddIstioAttributes, void(const std::string& data));
+  MOCK_METHOD1(ExtractIstioAttributes, bool(std::string *data));
+  MOCK_METHOD1(AddIstioAttributes, void(const std::string &data));
 
-  MOCK_CONST_METHOD2(GetSourceIpPort, bool(std::string* ip, int* port));
-  MOCK_CONST_METHOD1(GetSourceUser, bool(std::string* user));
+  MOCK_CONST_METHOD2(GetSourceIpPort, bool(std::string *ip, int *port));
+  MOCK_CONST_METHOD1(GetSourceUser, bool(std::string *user));
   MOCK_CONST_METHOD0(GetRequestHeaders, std::map<std::string, std::string>());
   MOCK_CONST_METHOD2(FindHeaderByType,
-                     bool(HeaderType header_type, std::string* value));
+                     bool(HeaderType header_type, std::string *value));
   MOCK_CONST_METHOD2(FindHeaderByName,
-                     bool(const std::string& name, std::string* value));
+                     bool(const std::string &name, std::string *value));
   MOCK_CONST_METHOD2(FindQueryParameter,
-                     bool(const std::string& name, std::string* value));
+                     bool(const std::string &name, std::string *value));
   MOCK_CONST_METHOD2(FindCookie,
-                     bool(const std::string& name, std::string* value));
-  MOCK_CONST_METHOD1(GetAuthenticationHeader,
-                     bool(std::map<std::string, std::string>* attrs));
+                     bool(const std::string &name, std::string *value));
+  MOCK_CONST_METHOD1(GetJWTPayload,
+                     bool(std::map<std::string, std::string> *payload));
 };
 
 }  // namespace http


### PR DESCRIPTION
**What this PR does / why we need it**: Extracts information from "sec-istio-auth-userinfo" header which is generated from auth filter, and generates authentication attributes for mixer server to check. This is part of efforts that enable auth filter in envoy.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```