### PR TITLE
Auth report

### DIFF
--- a/control/include/http/check_data.h
+++ b/control/include/http/check_data.h
@@ -78,18 +78,18 @@ class CheckData {
       std::map<std::string, std::string> *payload) const = 0;
 };
 
-// An interfact to update request headers
+// An interfact to update request HTTP headers with Istio attributes.
 class HeaderUpdate {
  public:
-  virtual ~UpdateRequestHeader() {}
+  virtual ~HeaderUpdate() {}
 
   // Remove "x-istio-attributes" HTTP header.
-  virtual bool RemoveIstioAttributes() = 0;
+  virtual void RemoveIstioAttributes() = 0;
 
   // Base64 encode data, and add it as "x-istio-attributes" HTTP header.
   virtual void AddIstioAttributes(const std::string &data) = 0;
 };
- 
+
 }  // namespace http
 }  // namespace mixer_control
 }  // namespace istio

--- a/control/include/http/check_data.h
+++ b/control/include/http/check_data.h
@@ -31,11 +31,7 @@ class CheckData {
 
   // Find "x-istio-attributes" HTTP header.
   // If found, base64 decode its value,  pass it out
-  // and remove the HTTP header from the request.
-  virtual bool ExtractIstioAttributes(std::string *data) = 0;
-
-  // Base64 encode data, and add it as "x-istio-attributes" HTTP header.
-  virtual void AddIstioAttributes(const std::string &data) = 0;
+  virtual bool ExtractIstioAttributes(std::string *data) const = 0;
 
   // Get downstream tcp connection ip and port.
   virtual bool GetSourceIpPort(std::string *ip, int *port) const = 0;
@@ -82,6 +78,18 @@ class CheckData {
       std::map<std::string, std::string> *payload) const = 0;
 };
 
+// An interfact to update request headers
+class HeaderUpdate {
+ public:
+  virtual ~UpdateRequestHeader() {}
+
+  // Remove "x-istio-attributes" HTTP header.
+  virtual bool RemoveIstioAttributes() = 0;
+
+  // Base64 encode data, and add it as "x-istio-attributes" HTTP header.
+  virtual void AddIstioAttributes(const std::string &data) = 0;
+};
+ 
 }  // namespace http
 }  // namespace mixer_control
 }  // namespace istio

--- a/control/include/http/request_handler.h
+++ b/control/include/http/request_handler.h
@@ -36,15 +36,30 @@ class RequestHandler {
   // * if necessary, forward some attributes to downstream
   // * make a Check call.
   virtual ::istio::mixer_client::CancelFunc Check(
-      CheckData* check_data,
+      CheckData* check_data, HeaderUpdate* header_update,
       ::istio::mixer_client::TransportCheckFunc transport,
       ::istio::mixer_client::DoneFunc on_done) = 0;
-
+  
   // Make a Report call. It will:
   // * check service config to see if Report is required
   // * extract more report attributes
   // * make a Report call.
   virtual void Report(ReportData* report_data) = 0;
+
+  // Extract the request attributes for Report() call.
+  // This is called at Report time when Check() is not called.
+  // Normally request attributes are extracted at Check() call.
+  // This is for cases the requests are rejected by http filters
+  // before mixer, such as fault injection, or auth.
+  //
+  // Usage:  at Envoy filter::log() function
+  //   if (!hander) {
+  //       handle = control->CreateHandler();
+  //       handler->ExtractRequestAttributes();
+  //   }
+  //   handler->Report();
+  //
+  virtual void ExtractRequestAttributes(CheckData* check_data) = 0;
 };
 
 }  // namespace http

--- a/control/include/http/request_handler.h
+++ b/control/include/http/request_handler.h
@@ -39,7 +39,7 @@ class RequestHandler {
       CheckData* check_data, HeaderUpdate* header_update,
       ::istio::mixer_client::TransportCheckFunc transport,
       ::istio::mixer_client::DoneFunc on_done) = 0;
-  
+
   // Make a Report call. It will:
   // * check service config to see if Report is required
   // * extract more report attributes

--- a/control/src/http/attributes_builder.cc
+++ b/control/src/http/attributes_builder.cc
@@ -120,10 +120,10 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData *check_data) {
 }
 
 void AttributesBuilder::ForwardAttributes(const Attributes &forward_attributes,
-                                          CheckData *check_data) {
+                                          HeaderUpdate* header_update) {
   std::string str;
   forward_attributes.SerializeToString(&str);
-  check_data->AddIstioAttributes(str);
+  header_update->AddIstioAttributes(str);
 }
 
 void AttributesBuilder::ExtractReportAttributes(ReportData *report_data) {

--- a/control/src/http/attributes_builder.cc
+++ b/control/src/http/attributes_builder.cc
@@ -120,7 +120,7 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData *check_data) {
 }
 
 void AttributesBuilder::ForwardAttributes(const Attributes &forward_attributes,
-                                          HeaderUpdate* header_update) {
+                                          HeaderUpdate *header_update) {
   std::string str;
   forward_attributes.SerializeToString(&str);
   header_update->AddIstioAttributes(str);

--- a/control/src/http/attributes_builder.h
+++ b/control/src/http/attributes_builder.h
@@ -33,7 +33,7 @@ class AttributesBuilder {
   void ExtractForwardedAttributes(CheckData* check_data);
   // Forward attributes to upstream proxy.
   static void ForwardAttributes(
-      const ::istio::mixer::v1::Attributes& attributes, CheckData* check_data);
+      const ::istio::mixer::v1::Attributes& attributes, HeaderUpdate* header_update);
 
   // Extract attributes for Check call.
   void ExtractCheckAttributes(CheckData* check_data);

--- a/control/src/http/attributes_builder.h
+++ b/control/src/http/attributes_builder.h
@@ -33,7 +33,8 @@ class AttributesBuilder {
   void ExtractForwardedAttributes(CheckData* check_data);
   // Forward attributes to upstream proxy.
   static void ForwardAttributes(
-      const ::istio::mixer::v1::Attributes& attributes, HeaderUpdate* header_update);
+      const ::istio::mixer::v1::Attributes& attributes,
+      HeaderUpdate* header_update);
 
   // Extract attributes for Check call.
   void ExtractCheckAttributes(CheckData* check_data);

--- a/control/src/http/attributes_builder_test.cc
+++ b/control/src/http/attributes_builder_test.cc
@@ -253,8 +253,8 @@ TEST(AttributesBuilderTest, TestExtractV2ForwardedAttributes) {
 
 TEST(AttributesBuilderTest, TestForwardAttributes) {
   Attributes forwarded_attr;
-  ::testing::NiceMock<MockCheckData> mock_data;
-  EXPECT_CALL(mock_data, AddIstioAttributes(_))
+  ::testing::NiceMock<MockHeaderUpdate> mock_header;
+  EXPECT_CALL(mock_header, AddIstioAttributes(_))
       .WillOnce(Invoke([&forwarded_attr](const std::string &data) {
         EXPECT_TRUE(forwarded_attr.ParseFromString(data));
       }));
@@ -263,7 +263,7 @@ TEST(AttributesBuilderTest, TestForwardAttributes) {
   (*origin_attr.mutable_attributes())["test_key"].set_string_value(
       "test_value");
 
-  AttributesBuilder::ForwardAttributes(origin_attr, &mock_data);
+  AttributesBuilder::ForwardAttributes(origin_attr, &mock_header);
   EXPECT_TRUE(MessageDifferencer::Equals(origin_attr, forwarded_attr));
 }
 

--- a/control/src/http/mock_check_data.h
+++ b/control/src/http/mock_check_data.h
@@ -26,8 +26,7 @@ namespace http {
 // The mock object for CheckData interface.
 class MockCheckData : public CheckData {
  public:
-  MOCK_METHOD1(ExtractIstioAttributes, bool(std::string *data));
-  MOCK_METHOD1(AddIstioAttributes, void(const std::string &data));
+  MOCK_CONST_METHOD1(ExtractIstioAttributes, bool(std::string *data));
 
   MOCK_CONST_METHOD2(GetSourceIpPort, bool(std::string *ip, int *port));
   MOCK_CONST_METHOD1(GetSourceUser, bool(std::string *user));
@@ -44,6 +43,13 @@ class MockCheckData : public CheckData {
                      bool(std::map<std::string, std::string> *payload));
 };
 
+// The mock object for HeaderUpdate interface.
+class MockHeaderUpdate : public HeaderUpdate {
+ public:
+  MOCK_METHOD0(RemoveIstioAttributes, void());
+  MOCK_METHOD1(AddIstioAttributes, void(const std::string &data));
+};
+ 
 }  // namespace http
 }  // namespace mixer_control
 }  // namespace istio

--- a/control/src/http/mock_check_data.h
+++ b/control/src/http/mock_check_data.h
@@ -49,7 +49,7 @@ class MockHeaderUpdate : public HeaderUpdate {
   MOCK_METHOD0(RemoveIstioAttributes, void());
   MOCK_METHOD1(AddIstioAttributes, void(const std::string &data));
 };
- 
+
 }  // namespace http
 }  // namespace mixer_control
 }  // namespace istio

--- a/control/src/http/request_handler_impl.cc
+++ b/control/src/http/request_handler_impl.cc
@@ -30,9 +30,7 @@ RequestHandlerImpl::RequestHandlerImpl(
     std::shared_ptr<ServiceContext> service_context)
     : service_context_(service_context) {}
 
-CancelFunc RequestHandlerImpl::Check(CheckData* check_data,
-                                     TransportCheckFunc transport,
-                                     DoneFunc on_done) {
+void RequestHandlerImpl::ExtractRequestAttributes(CheckData* check_data) {
   if (service_context_->enable_mixer_check() ||
       service_context_->enable_mixer_report()) {
     service_context_->AddStaticAttributes(&request_context_);
@@ -43,11 +41,20 @@ CancelFunc RequestHandlerImpl::Check(CheckData* check_data,
 
     service_context_->AddApiAttributes(check_data, &request_context_);
   }
-
+}
+  
+CancelFunc RequestHandlerImpl::Check(CheckData* check_data,
+				     HeaderUpdate* header_update,
+                                     TransportCheckFunc transport,
+                                     DoneFunc on_done) {
+  ExtractRequestAttributes(check_data);
+  
   if (service_context_->client_context()->config().has_forward_attributes()) {
     AttributesBuilder::ForwardAttributes(
         service_context_->client_context()->config().forward_attributes(),
-        check_data);
+        header_update);
+  } else {
+    header_update->RemoveIstioAttributes();
   }
 
   if (!service_context_->enable_mixer_check()) {

--- a/control/src/http/request_handler_impl.cc
+++ b/control/src/http/request_handler_impl.cc
@@ -42,13 +42,13 @@ void RequestHandlerImpl::ExtractRequestAttributes(CheckData* check_data) {
     service_context_->AddApiAttributes(check_data, &request_context_);
   }
 }
-  
+
 CancelFunc RequestHandlerImpl::Check(CheckData* check_data,
-				     HeaderUpdate* header_update,
+                                     HeaderUpdate* header_update,
                                      TransportCheckFunc transport,
                                      DoneFunc on_done) {
   ExtractRequestAttributes(check_data);
-  
+
   if (service_context_->client_context()->config().has_forward_attributes()) {
     AttributesBuilder::ForwardAttributes(
         service_context_->client_context()->config().forward_attributes(),

--- a/control/src/http/request_handler_impl.h
+++ b/control/src/http/request_handler_impl.h
@@ -32,7 +32,7 @@ class RequestHandlerImpl : public RequestHandler {
 
   // Makes a Check call.
   ::istio::mixer_client::CancelFunc Check(
-	  CheckData* check_data, HeaderUpdate* header_update,
+      CheckData* check_data, HeaderUpdate* header_update,
       ::istio::mixer_client::TransportCheckFunc transport,
       ::istio::mixer_client::DoneFunc on_done) override;
 

--- a/control/src/http/request_handler_impl.h
+++ b/control/src/http/request_handler_impl.h
@@ -32,12 +32,14 @@ class RequestHandlerImpl : public RequestHandler {
 
   // Makes a Check call.
   ::istio::mixer_client::CancelFunc Check(
-      CheckData* check_data,
+	  CheckData* check_data, HeaderUpdate* header_update,
       ::istio::mixer_client::TransportCheckFunc transport,
       ::istio::mixer_client::DoneFunc on_done) override;
 
   // Make a Report call.
   void Report(ReportData* report_data) override;
+
+  void ExtractRequestAttributes(CheckData* check_data) override;
 
  private:
   // The request context object.

--- a/control/src/http/request_handler_impl_test.cc
+++ b/control/src/http/request_handler_impl_test.cc
@@ -111,6 +111,7 @@ class RequestHandlerImplTest : public ::testing::Test {
 
 TEST_F(RequestHandlerImplTest, TestHandlerDisabledCheckReport) {
   ::testing::NiceMock<MockCheckData> mock_data;
+  ::testing::NiceMock<MockHeaderUpdate> mock_header;
   // Not to extract attributes since both Check and Report are disabled.
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(0);
   EXPECT_CALL(mock_data, GetSourceUser(_)).Times(0);
@@ -125,12 +126,13 @@ TEST_F(RequestHandlerImplTest, TestHandlerDisabledCheckReport) {
   config.legacy_config = &legacy;
 
   auto handler = controller_->CreateRequestHandler(config);
-  handler->Check(&mock_data, nullptr,
+  handler->Check(&mock_data, &mock_header, nullptr,
                  [](const Status& status) { EXPECT_TRUE(status.ok()); });
 }
 
 TEST_F(RequestHandlerImplTest, TestHandlerDisabledCheck) {
   ::testing::NiceMock<MockCheckData> mock_data;
+  ::testing::NiceMock<MockHeaderUpdate> mock_header;
   // Report is enabled so Attributes are extracted.
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
   EXPECT_CALL(mock_data, GetSourceUser(_)).Times(1);
@@ -144,12 +146,13 @@ TEST_F(RequestHandlerImplTest, TestHandlerDisabledCheck) {
   config.legacy_config = &legacy;
 
   auto handler = controller_->CreateRequestHandler(config);
-  handler->Check(&mock_data, nullptr,
+  handler->Check(&mock_data, &mock_header, nullptr,
                  [](const Status& status) { EXPECT_TRUE(status.ok()); });
 }
 
 TEST_F(RequestHandlerImplTest, TestLegacyRoute) {
   ::testing::NiceMock<MockCheckData> mock_data;
+  ::testing::NiceMock<MockHeaderUpdate> mock_header;
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
   EXPECT_CALL(mock_data, GetSourceUser(_)).Times(1);
 
@@ -176,11 +179,12 @@ TEST_F(RequestHandlerImplTest, TestLegacyRoute) {
   (*map2)["legacy-key"].set_string_value("legacy-value");
 
   auto handler = controller_->CreateRequestHandler(config);
-  handler->Check(&mock_data, nullptr, nullptr);
+  handler->Check(&mock_data, &mock_header, nullptr, nullptr);
 }
 
 TEST_F(RequestHandlerImplTest, TestDefaultRouteAttributes) {
   ::testing::NiceMock<MockCheckData> mock_data;
+  ::testing::NiceMock<MockHeaderUpdate> mock_header;
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
   EXPECT_CALL(mock_data, GetSourceUser(_)).Times(1);
 
@@ -199,11 +203,12 @@ TEST_F(RequestHandlerImplTest, TestDefaultRouteAttributes) {
   // destionation.server is empty, will use default one
   Controller::PerRouteConfig config;
   auto handler = controller_->CreateRequestHandler(config);
-  handler->Check(&mock_data, nullptr, nullptr);
+  handler->Check(&mock_data, &mock_header, nullptr, nullptr);
 }
 
 TEST_F(RequestHandlerImplTest, TestRouteAttributes) {
   ::testing::NiceMock<MockCheckData> mock_data;
+  ::testing::NiceMock<MockHeaderUpdate> mock_header;
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
   EXPECT_CALL(mock_data, GetSourceUser(_)).Times(1);
 
@@ -228,11 +233,12 @@ TEST_F(RequestHandlerImplTest, TestRouteAttributes) {
   Controller::PerRouteConfig config;
   config.destination_service = "route1";
   auto handler = controller_->CreateRequestHandler(config);
-  handler->Check(&mock_data, nullptr, nullptr);
+  handler->Check(&mock_data, &mock_header, nullptr, nullptr);
 }
 
 TEST_F(RequestHandlerImplTest, TestDefaultRouteQuota) {
   ::testing::NiceMock<MockCheckData> mock_data;
+  ::testing::NiceMock<MockHeaderUpdate> mock_header;
 
   ServiceConfig route_config;
   auto quota = route_config.add_quota_spec()->add_rules()->add_quotas();
@@ -259,11 +265,12 @@ TEST_F(RequestHandlerImplTest, TestDefaultRouteQuota) {
   // destionation.server is empty, will use default one
   Controller::PerRouteConfig config;
   auto handler = controller_->CreateRequestHandler(config);
-  handler->Check(&mock_data, nullptr, nullptr);
+  handler->Check(&mock_data, &mock_header, nullptr, nullptr);
 }
 
 TEST_F(RequestHandlerImplTest, TestDefaultRouteApiSpec) {
   ::testing::NiceMock<MockCheckData> mock_data;
+  ::testing::NiceMock<MockHeaderUpdate> mock_header;
   EXPECT_CALL(mock_data, FindHeaderByType(_, _))
       .WillRepeatedly(
           Invoke([](CheckData::HeaderType type, std::string* value) -> bool {
@@ -305,11 +312,12 @@ TEST_F(RequestHandlerImplTest, TestDefaultRouteApiSpec) {
   // destionation.server is empty, will use default one
   Controller::PerRouteConfig config;
   auto handler = controller_->CreateRequestHandler(config);
-  handler->Check(&mock_data, nullptr, nullptr);
+  handler->Check(&mock_data, &mock_header, nullptr, nullptr);
 }
 
 TEST_F(RequestHandlerImplTest, TestHandlerCheck) {
   ::testing::NiceMock<MockCheckData> mock_data;
+  ::testing::NiceMock<MockHeaderUpdate> mock_header;
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
   EXPECT_CALL(mock_data, GetSourceUser(_)).Times(1);
 
@@ -321,11 +329,12 @@ TEST_F(RequestHandlerImplTest, TestHandlerCheck) {
   config.legacy_config = &legacy;
 
   auto handler = controller_->CreateRequestHandler(config);
-  handler->Check(&mock_data, nullptr, nullptr);
+  handler->Check(&mock_data, &mock_header, nullptr, nullptr);
 }
 
 TEST_F(RequestHandlerImplTest, TestDefaultApiKey) {
   ::testing::NiceMock<MockCheckData> mock_data;
+  ::testing::NiceMock<MockHeaderUpdate> mock_header;
   EXPECT_CALL(mock_data, FindQueryParameter(_, _))
       .WillRepeatedly(
           Invoke([](const std::string& name, std::string* value) -> bool {
@@ -351,7 +360,7 @@ TEST_F(RequestHandlerImplTest, TestDefaultApiKey) {
   // destionation.server is empty, will use default one
   Controller::PerRouteConfig config;
   auto handler = controller_->CreateRequestHandler(config);
-  handler->Check(&mock_data, nullptr, nullptr);
+  handler->Check(&mock_data, &mock_header, nullptr, nullptr);
 }
 
 TEST_F(RequestHandlerImplTest, TestHandlerReport) {
@@ -391,12 +400,13 @@ TEST_F(RequestHandlerImplTest, TestEmptyConfig) {
   SetUpMockController(kEmptyClientConfig);
 
   ::testing::NiceMock<MockCheckData> mock_check;
+  ::testing::NiceMock<MockHeaderUpdate> mock_header;
   // Not to extract attributes since both Check and Report are disabled.
   EXPECT_CALL(mock_check, GetSourceIpPort(_, _)).Times(0);
   EXPECT_CALL(mock_check, GetSourceUser(_)).Times(0);
 
   // Attributes is forwarded.
-  EXPECT_CALL(mock_check, AddIstioAttributes(_))
+  EXPECT_CALL(mock_header, AddIstioAttributes(_))
       .WillOnce(Invoke([](const std::string& data) {
         Attributes forwarded_attr;
         EXPECT_TRUE(forwarded_attr.ParseFromString(data));
@@ -416,7 +426,7 @@ TEST_F(RequestHandlerImplTest, TestEmptyConfig) {
 
   Controller::PerRouteConfig config;
   auto handler = controller_->CreateRequestHandler(config);
-  handler->Check(&mock_check, nullptr,
+  handler->Check(&mock_check, &mock_header, nullptr,
                  [](const Status& status) { EXPECT_TRUE(status.ok()); });
   handler->Report(&mock_report);
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

To support sending Report for requests rejected by other filters, such as auth and fault injections.
1) add a new method ExtractRequestAttributes()
2) split CheckData interface into two: one is mutable, another is non-mutable.  Check() will take both interfaces, but ExtractRequestAttribute() only take non-mutable since its header_map could not be changed.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
