### PR TITLE
Not to log warning when converting empty ip attributes

### DIFF
--- a/src/attributes_builder.cc
+++ b/src/attributes_builder.cc
@@ -37,6 +37,11 @@ void AttributesBuilder::AddIpOrString(const std::string& name,
     return;
   }
 
+  if (value.empty()) {
+    AddBytes(name, value);
+    return;
+  }
+
   in_addr ipv4_bytes;
   if (inet_pton(AF_INET, value.c_str(), &ipv4_bytes) == 1) {
     AddBytes(name, std::string(reinterpret_cast<const char*>(&ipv4_bytes),


### PR DESCRIPTION
**What this PR does / why we need it**:

Don't try to convert empty IP string to bytes.  Just send it as empty bytes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
