### PR TITLE
Report http status code, regardless of check result

### DIFF
--- a/control/src/http/attributes_builder.cc
+++ b/control/src/http/attributes_builder.cc
@@ -143,7 +143,7 @@ void AttributesBuilder::ExtractReportAttributes(ReportData *report_data) {
   if (!request_->check_status.ok()) {
     builder.AddInt64(
         AttributeName::kResponseCode,
-	utils::StatusHttpCode(request_->check_status.error_code()));
+        utils::StatusHttpCode(request_->check_status.error_code()));
     builder.AddInt64(AttributeName::kCheckErrorCode,
                      request_->check_status.error_code());
     builder.AddString(AttributeName::kCheckErrorMessage,

--- a/control/src/http/attributes_builder.cc
+++ b/control/src/http/attributes_builder.cc
@@ -141,6 +141,9 @@ void AttributesBuilder::ExtractReportAttributes(ReportData *report_data) {
   builder.AddInt64(AttributeName::kResponseSize, info.send_bytes);
   builder.AddDuration(AttributeName::kResponseDuration, info.duration);
   if (!request_->check_status.ok()) {
+    builder.AddInt64(
+        AttributeName::kResponseCode,
+	utils::StatusHttpCode(request_->check_status.error_code()));
     builder.AddInt64(AttributeName::kCheckErrorCode,
                      request_->check_status.error_code());
     builder.AddString(AttributeName::kCheckErrorMessage,


### PR DESCRIPTION
**What this PR does / why we need it**:
Ensures that http status code is reported regardless of whether it was a result of a check failure or came from the back end.
 
**Which issue this PR fixes** 
Fixes issue when 429 response was received by the client, but "report" call omitted `response.code`. This results in inconsistent metrics reporting and hence failed mixer e2e test.
 