### PR TITLE
Add Bazel bzl files from api.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -24,12 +24,12 @@ py_binary(
 genrule(
    name = "global_dictionary_header_gen",
    srcs = [
-       "@mixerapi_git//mixer/v1:attributes_file",
+       "@mixerapi_git//:global_dictionary_file",
    ],
    outs = [
        "src/global_dictionary.cc",
    ],
-   cmd = "$(location //:create_global_dictionary) $(location @mixerapi_git//mixer/v1:attributes_file) > $@",
+   cmd = "$(location //:create_global_dictionary) $(location @mixerapi_git//:global_dictionary_file) > $@",
    tools = [
         "//:create_global_dictionary",
    ],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,20 +18,15 @@ load(
     "//:repositories.bzl",
     "boringssl_repositories",
     "googletest_repositories",
-    "mixerapi_repositories",
+    "mixerapi_dependencies",
 )
 
 boringssl_repositories()
 googletest_repositories()
-
-mixerapi_repositories()
+mixerapi_dependencies()
 
 git_repository(
-    name = "io_bazel_rules_go",
-    commit = "9cf23e2aab101f86e4f51d8c5e0f14c012c2161c",  # Oct 12, 2017 (Add `build_external` option to `go_repository`)
-    remote = "https://github.com/bazelbuild/rules_go.git",
+    name = "org_pubref_rules_protobuf",
+    commit = "563b674a2ce6650d459732932ea2bc98c9c9a9bf",  # Nov 28, 2017 (bazel 0.8.0 support)
+    remote = "https://github.com/pubref/rules_protobuf",
 )
-
-load("@mixerapi_git//:api_dependencies.bzl", "mixer_api_dependencies")
-mixer_api_dependencies()
-

--- a/cc_gogo_protobuf.bzl
+++ b/cc_gogo_protobuf.bzl
@@ -1,0 +1,73 @@
+# Copyright 2017 Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+def cc_gogoproto_repositories(bind=True):
+    BUILD = """
+# Copyright 2017 Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+
+licenses(["notice"])
+
+load("@com_google_protobuf//:protobuf.bzl", "cc_proto_library")
+
+exports_files(glob(["google/**"]))
+
+cc_proto_library(
+    name = "cc_gogoproto",
+    srcs = [
+        "gogoproto/gogo.proto",
+    ],
+    include = ".",
+    default_runtime = "//external:protobuf",
+    protoc = "//external:protoc",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//external:cc_wkt_protos",
+    ],
+)
+"""
+    native.new_git_repository(
+        name = "gogoproto_git",
+        commit = "100ba4e885062801d56799d78530b73b178a78f3",
+        remote = "https://github.com/gogo/protobuf",
+        build_file_content = BUILD,
+    )
+
+    if bind:
+        native.bind(
+            name = "cc_gogoproto",
+            actual = "@gogoproto_git//:cc_gogoproto",
+        )
+
+        native.bind(
+            name = "cc_gogoproto_genproto",
+            actual = "@gogoproto_git//:cc_gogoproto_genproto",
+        )
+

--- a/googleapis.bzl
+++ b/googleapis.bzl
@@ -1,0 +1,54 @@
+# Copyright 2017 Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+
+def googleapis_repositories(bind=True):
+    GOOGLEAPIS_BUILD_FILE = """
+package(default_visibility = ["//visibility:public"])
+
+load("@com_google_protobuf//:protobuf.bzl", "cc_proto_library")
+
+cc_proto_library(
+    name = "rpc_status_proto",
+    srcs = [
+        "google/rpc/status.proto",
+    ],
+    visibility = ["//visibility:public"],
+    protoc = "//external:protoc",
+    default_runtime = "//external:protobuf",
+    deps = [
+        "//external:cc_wkt_protos",
+    ],
+)
+
+"""
+    native.new_git_repository(
+        name = "com_github_googleapis_googleapis",
+        build_file_content = GOOGLEAPIS_BUILD_FILE,
+        commit = "13ac2436c5e3d568bd0e938f6ed58b77a48aba15", # Oct 21, 2016 (only release pre-dates sha)
+        remote = "https://github.com/googleapis/googleapis.git",
+    )
+
+    if bind:
+        native.bind(
+            name = "rpc_status_proto",
+            actual = "@com_github_googleapis_googleapis//:rpc_status_proto",
+        )
+        native.bind(
+            name = "rpc_status_proto_genproto",
+            actual = "@com_github_googleapis_googleapis//:rpc_status_proto_genproto",
+        )
+

--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -1,0 +1,61 @@
+# Copyright 2017 Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+
+def protobuf_repositories(load_repo=True, bind=True):
+    if load_repo:
+        native.git_repository(
+            name = "com_google_protobuf",
+            commit = "2761122b810fe8861004ae785cc3ab39f384d342",  # v3.5.0
+            remote = "https://github.com/google/protobuf.git",
+        )
+
+    if bind:
+        native.bind(
+            name = "protoc",
+            actual = "@com_google_protobuf//:protoc",
+        )
+
+        native.bind(
+            name = "protocol_compiler",
+            actual = "@com_google_protobuf//:protoc",
+        )
+
+        native.bind(
+            name = "protobuf",
+            actual = "@com_google_protobuf//:protobuf",
+        )
+
+        native.bind(
+            name = "cc_wkt_protos",
+            actual = "@com_google_protobuf//:cc_wkt_protos",
+        )
+
+        native.bind(
+            name = "cc_wkt_protos_genproto",
+            actual = "@com_google_protobuf//:cc_wkt_protos_genproto",
+        )
+
+        native.bind(
+            name = "protobuf_compiler",
+            actual = "@com_google_protobuf//:protoc_lib",
+        )
+
+        native.bind(
+            name = "protobuf_clib",
+            actual = "@com_google_protobuf//:protoc_lib",
+        )
+

--- a/x_tools_imports.bzl
+++ b/x_tools_imports.bzl
@@ -1,0 +1,53 @@
+# Copyright 2017 Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+
+def go_x_tools_imports_repositories():
+    BUILD_FILE = """
+package(default_visibility = ["//visibility:public"])
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+load("@io_bazel_rules_go//go:def.bzl", "go_prefix")
+
+go_prefix("golang.org/x/tools")
+
+licenses(["notice"])  # New BSD
+
+exports_files(["LICENSE"])
+
+go_binary(
+    name = "goimports",
+    srcs = [
+        "cmd/goimports/doc.go",
+        "cmd/goimports/goimports.go",
+        "cmd/goimports/goimports_gc.go",
+        "cmd/goimports/goimports_not_gc.go",
+    ],
+    deps = [
+        "@org_golang_x_tools//imports:go_default_library",
+    ],
+)
+"""
+    # bazel rule for fixing up cfg.pb.go relies on running goimports
+    # we import it here as a git repository to allow projection of a
+    # simple build rule that will build the binary for usage (and avoid
+    # the need to project a more complicated BUILD file over the entire
+    # tools repo.)
+    native.new_git_repository(
+	name = "org_golang_x_tools_imports",
+        build_file_content = BUILD_FILE,
+        commit = "e6cb469339aef5b7be0c89de730d5f3cc8e47e50",  # Jun 23, 2017 (no releases)
+        remote = "https://github.com/golang/tools.git",
+    )


### PR DESCRIPTION
**What this PR does / why we need it**:

* istio/api repo removed all bazel bzl files used by mixerclient and proxy.
* Move these files into this repo

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
