### PR TITLE
Add LRU cache for service config.

### DIFF
--- a/control/include/http/controller.h
+++ b/control/include/http/controller.h
@@ -70,6 +70,7 @@ class Controller {
   // The initial data required by the Controller. It needs:
   // * client_config: the mixer client config.
   // * some functions provided by the environment (Envoy)
+  // * optional service config cache size.
   struct Options {
     Options(const ::istio::mixer::v1::config::client::HttpClientConfig& config,
             const std::vector<::istio::quota::Requirement>& legacy_quotas)

--- a/control/include/http/controller.h
+++ b/control/include/http/controller.h
@@ -31,11 +31,30 @@ class Controller {
  public:
   virtual ~Controller() {}
 
+  // Following two functions are used to manage service configs.
+  // Callers should call LookupServiceConfig to lookup the config with id
+  // and use AddServiceConfig to add the config if it is new.
+
+  // Lookup a service config by its config id. Return true if found.
+  virtual bool LookupServiceConfig(const std::string& service_config_id) = 0;
+
+  // Add a new service config.
+  virtual void AddServiceConfig(
+      const std::string& service_config_id,
+      const ::istio::mixer::v1::config::client::ServiceConfig& config) = 0;
+
   // A data struct to pass in per-route config.
   struct PerRouteConfig {
     // The per route destination.server name.
     // It will be used to lookup per route config map.
     std::string destination_service;
+
+    // A unique ID to identify a config version for a service.
+    // Usually it is a sha of the whole service config.
+    // The config should have been added by AddServiceConfig().
+    // If it is empty, destination_service is used to lookup
+    // service_configs map in the HttpClientConfig.
+    std::string service_config_id;
 
     // if not NULL, legacy per-route config for 0.2 and before.
     const ::istio::mixer::v1::config::client::ServiceConfig* legacy_config{};
@@ -64,6 +83,10 @@ class Controller {
 
     // Some plaform functions for mixer client library.
     ::istio::mixer_client::Environment env;
+
+    // The LRU cache size for service config.
+    // If not set or is 0 default value, the cache size is 1000.
+    int service_config_cache_size{};
   };
 
   // The factory function to create a new instance of the controller.

--- a/control/src/http/client_context.cc
+++ b/control/src/http/client_context.cc
@@ -24,15 +24,18 @@ namespace http {
 ClientContext::ClientContext(const Controller::Options& data)
     : ClientContextBase(data.config.transport(), data.env),
       config_(data.config),
-      legacy_quotas_(data.legacy_quotas) {}
+      legacy_quotas_(data.legacy_quotas),
+      service_config_cache_size_(data.service_config_cache_size) {}
 
 ClientContext::ClientContext(
     std::unique_ptr<::istio::mixer_client::MixerClient> mixer_client,
     const ::istio::mixer::v1::config::client::HttpClientConfig& config,
-    const std::vector<::istio::quota::Requirement>& legacy_quotas)
+    const std::vector<::istio::quota::Requirement>& legacy_quotas,
+    int service_config_cache_size)
     : ClientContextBase(std::move(mixer_client)),
       config_(config),
-      legacy_quotas_(legacy_quotas) {}
+      legacy_quotas_(legacy_quotas),
+      service_config_cache_size_(service_config_cache_size) {}
 
 void ClientContext::AddLegacyQuotas(
     std::vector<::istio::quota::Requirement>* quotas) const {

--- a/control/src/http/client_context.h
+++ b/control/src/http/client_context.h
@@ -63,7 +63,7 @@ class ClientContext : public ClientContextBase {
   // Legacy mixer config quota requirements.
   const std::vector<::istio::quota::Requirement>& legacy_quotas_;
 
-  // The service config cacie size
+  // The service config cache size
   int service_config_cache_size_;
 };
 

--- a/control/src/http/client_context.h
+++ b/control/src/http/client_context.h
@@ -33,7 +33,8 @@ class ClientContext : public ClientContextBase {
   ClientContext(
       std::unique_ptr<::istio::mixer_client::MixerClient> mixer_client,
       const ::istio::mixer::v1::config::client::HttpClientConfig& config,
-      const std::vector<::istio::quota::Requirement>& legacy_quotas);
+      const std::vector<::istio::quota::Requirement>& legacy_quotas,
+      int service_config_cache_size);
 
   // Retrieve mixer client config.
   const ::istio::mixer::v1::config::client::HttpClientConfig& config() const {
@@ -52,12 +53,18 @@ class ClientContext : public ClientContextBase {
   const ::istio::mixer::v1::config::client::ServiceConfig* GetServiceConfig(
       const std::string& service_name) const;
 
+  // Get the service config cache size
+  int service_config_cache_size() const { return service_config_cache_size_; }
+
  private:
   // The http client config.
   const ::istio::mixer::v1::config::client::HttpClientConfig& config_;
 
   // Legacy mixer config quota requirements.
   const std::vector<::istio::quota::Requirement>& legacy_quotas_;
+
+  // The service config cacie size
+  int service_config_cache_size_;
 };
 
 }  // namespace http


### PR DESCRIPTION
**What this PR does / why we need it**:

To support dynamic service config change.
service config is coming from Envoy per-route in RDS.  It can be changed overtime without re-contructing mixer fitter or mixer client control object.   
Add a LRU cache to store these known service config.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
