### PR TITLE
Introduce new attribute connection.mtls

### DIFF
--- a/control/include/http/check_data.h
+++ b/control/include/http/check_data.h
@@ -43,7 +43,7 @@ class CheckData {
   virtual std::map<std::string, std::string> GetRequestHeaders() const = 0;
 
   // Returns true if connection is mutual TLS enabled.
-  virtual bool IsMutualTlsEnabledConnection() const = 0;
+  virtual bool IsMutualTLS() const = 0;
 
   // These headers are extracted into top level attributes.
   // This is for standard HTTP headers.  It supports both HTTP/1.1 and HTTP2

--- a/control/include/http/check_data.h
+++ b/control/include/http/check_data.h
@@ -42,6 +42,9 @@ class CheckData {
   // Get request HTTP headers
   virtual std::map<std::string, std::string> GetRequestHeaders() const = 0;
 
+  // Returns true if connection is mutual TLS enabled.
+  virtual bool IsMutualTlsEnabledConnection() const = 0;
+
   // These headers are extracted into top level attributes.
   // This is for standard HTTP headers.  It supports both HTTP/1.1 and HTTP2
   // They can be retrieved at O(1) speed by environment (Envoy).

--- a/control/include/http/report_data.h
+++ b/control/include/http/report_data.h
@@ -29,6 +29,9 @@ class ReportData {
  public:
   virtual ~ReportData() {}
 
+  // Get upstream tcp connection ip and port.
+  virtual bool GetDestinationIpPort(std::string* ip, int* port) const = 0;
+
   // Get response HTTP headers.
   virtual std::map<std::string, std::string> GetResponseHeaders() const = 0;
 

--- a/control/include/http/report_data.h
+++ b/control/include/http/report_data.h
@@ -29,7 +29,7 @@ class ReportData {
  public:
   virtual ~ReportData() {}
 
-  // Get upstream tcp connection ip and port.
+  // Get upstream tcp connection IP and port. IP is returned in format of bytes.
   virtual bool GetDestinationIpPort(std::string* ip, int* port) const = 0;
 
   // Get response HTTP headers.

--- a/control/include/tcp/check_data.h
+++ b/control/include/tcp/check_data.h
@@ -33,6 +33,9 @@ class CheckData {
 
   // If SSL is used, get origin user name.
   virtual bool GetSourceUser(std::string* user) const = 0;
+
+  // Returns true if connection is mutual TLS enabled.
+  virtual bool IsMutualTlsEnabledConnection() const = 0;
 };
 
 }  // namespace tcp

--- a/control/include/tcp/check_data.h
+++ b/control/include/tcp/check_data.h
@@ -35,7 +35,7 @@ class CheckData {
   virtual bool GetSourceUser(std::string* user) const = 0;
 
   // Returns true if connection is mutual TLS enabled.
-  virtual bool IsMutualTlsEnabledConnection() const = 0;
+  virtual bool IsMutualTLS() const = 0;
 };
 
 }  // namespace tcp

--- a/control/include/tcp/report_data.h
+++ b/control/include/tcp/report_data.h
@@ -29,7 +29,7 @@ class ReportData {
  public:
   virtual ~ReportData() {}
 
-  // Get upstream tcp connection ip and port.
+  // Get upstream tcp connection IP and port. IP is returned in format of bytes.
   virtual bool GetDestinationIpPort(std::string* ip, int* port) const = 0;
 
   // Get additional report data.

--- a/control/src/attribute_names.cc
+++ b/control/src/attribute_names.cc
@@ -53,6 +53,7 @@ const char AttributeName::kConnectionSendBytes[] = "connection.sent.bytes";
 const char AttributeName::kConnectionSendTotalBytes[] =
     "connection.sent.bytes_total";
 const char AttributeName::kConnectionDuration[] = "connection.duration";
+const char AttributeName::kConnectionMtls[] = "connection.mtls";
 
 // Context attributes
 const char AttributeName::kContextProtocol[] = "context.protocol";

--- a/control/src/attribute_names.h
+++ b/control/src/attribute_names.h
@@ -55,6 +55,7 @@ struct AttributeName {
   static const char kConnectionSendBytes[];
   static const char kConnectionSendTotalBytes[];
   static const char kConnectionDuration[];
+  static const char kConnectionMtls[];
 
   // Context attributes
   static const char kContextProtocol[];

--- a/control/src/http/attributes_builder.cc
+++ b/control/src/http/attributes_builder.cc
@@ -109,6 +109,8 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData *check_data) {
     builder.AddBytes(AttributeName::kSourceIp, source_ip);
     builder.AddInt64(AttributeName::kSourcePort, source_port);
   }
+  builder.AddBool(AttributeName::kConnectionMtls,
+                  check_data->IsMutualTlsEnabledConnection());
 
   std::string source_user;
   if (check_data->GetSourceUser(&source_user)) {
@@ -128,6 +130,14 @@ void AttributesBuilder::ForwardAttributes(const Attributes &forward_attributes,
 
 void AttributesBuilder::ExtractReportAttributes(ReportData *report_data) {
   ::istio::mixer_client::AttributesBuilder builder(&request_->attributes);
+
+  std::string dest_ip;
+  int dest_port;
+  if (report_data->GetDestinationIpPort(&dest_ip, &dest_port)) {
+    builder.AddBytes(AttributeName::kDestinationIp, dest_ip);
+    builder.AddInt64(AttributeName::kDestinationPort, dest_port);
+  }
+
   std::map<std::string, std::string> headers =
       report_data->GetResponseHeaders();
   builder.AddStringMap(AttributeName::kResponseHeaders, headers);

--- a/control/src/http/attributes_builder.cc
+++ b/control/src/http/attributes_builder.cc
@@ -109,8 +109,7 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData *check_data) {
     builder.AddBytes(AttributeName::kSourceIp, source_ip);
     builder.AddInt64(AttributeName::kSourcePort, source_port);
   }
-  builder.AddBool(AttributeName::kConnectionMtls,
-                  check_data->IsMutualTlsEnabledConnection());
+  builder.AddBool(AttributeName::kConnectionMtls, check_data->IsMutualTLS());
 
   std::string source_user;
   if (check_data->GetSourceUser(&source_user)) {

--- a/control/src/http/attributes_builder_test.cc
+++ b/control/src/http/attributes_builder_test.cc
@@ -298,8 +298,9 @@ TEST(AttributesBuilderTest, TestCheckAttributes) {
         *user = "test_user";
         return true;
       }));
-  EXPECT_CALL(mock_data, IsMutualTlsEnabledConnection())
-      .WillOnce(Invoke([]() -> bool { return true; }));
+  EXPECT_CALL(mock_data, IsMutualTLS()).WillOnce(Invoke([]() -> bool {
+    return true;
+  }));
   EXPECT_CALL(mock_data, GetRequestHeaders())
       .WillOnce(Invoke([]() -> std::map<std::string, std::string> {
         std::map<std::string, std::string> map;

--- a/control/src/http/attributes_builder_test.cc
+++ b/control/src/http/attributes_builder_test.cc
@@ -298,9 +298,8 @@ TEST(AttributesBuilderTest, TestCheckAttributes) {
         *user = "test_user";
         return true;
       }));
-  EXPECT_CALL(mock_data, IsMutualTLS()).WillOnce(Invoke([]() -> bool {
-    return true;
-  }));
+  EXPECT_CALL(mock_data, IsMutualTLS())
+      .WillOnce(Invoke([]() -> bool { return true; }));
   EXPECT_CALL(mock_data, GetRequestHeaders())
       .WillOnce(Invoke([]() -> std::map<std::string, std::string> {
         std::map<std::string, std::string> map;

--- a/control/src/http/attributes_builder_test.cc
+++ b/control/src/http/attributes_builder_test.cc
@@ -23,10 +23,10 @@
 #include "mock_check_data.h"
 #include "mock_report_data.h"
 
-using ::istio::mixer::v1::Attributes;
-using ::istio::mixer::v1::Attributes_StringMap;
 using ::google::protobuf::TextFormat;
 using ::google::protobuf::util::MessageDifferencer;
+using ::istio::mixer::v1::Attributes;
+using ::istio::mixer::v1::Attributes_StringMap;
 
 using ::testing::_;
 using ::testing::Invoke;
@@ -93,6 +93,12 @@ attributes {
   key: "source.port"
   value {
     int64_value: 8080
+  }
+}
+attributes {
+  key: "connection.mtls"
+  value {
+    bool_value: true
   }
 }
 attributes {
@@ -175,6 +181,18 @@ attributes {
     duration_value {
       nanos: 1
     }
+  }
+}
+attributes {
+  key: "destination.ip"
+  value {
+    bytes_value: "1.2.3.4"
+  }
+}
+attributes {
+  key: "destination.port"
+  value {
+    int64_value: 8080
   }
 }
 attributes {
@@ -280,6 +298,8 @@ TEST(AttributesBuilderTest, TestCheckAttributes) {
         *user = "test_user";
         return true;
       }));
+  EXPECT_CALL(mock_data, IsMutualTlsEnabledConnection())
+      .WillOnce(Invoke([]() -> bool { return true; }));
   EXPECT_CALL(mock_data, GetRequestHeaders())
       .WillOnce(Invoke([]() -> std::map<std::string, std::string> {
         std::map<std::string, std::string> map;
@@ -330,6 +350,12 @@ TEST(AttributesBuilderTest, TestCheckAttributes) {
 
 TEST(AttributesBuilderTest, TestReportAttributes) {
   ::testing::NiceMock<MockReportData> mock_data;
+  EXPECT_CALL(mock_data, GetDestinationIpPort(_, _))
+      .WillOnce(Invoke([](std::string *ip, int *port) -> bool {
+        *ip = "1.2.3.4";
+        *port = 8080;
+        return true;
+      }));
   EXPECT_CALL(mock_data, GetResponseHeaders())
       .WillOnce(Invoke([]() -> std::map<std::string, std::string> {
         std::map<std::string, std::string> map;

--- a/control/src/http/mock_check_data.h
+++ b/control/src/http/mock_check_data.h
@@ -41,7 +41,7 @@ class MockCheckData : public CheckData {
                      bool(const std::string &name, std::string *value));
   MOCK_CONST_METHOD1(GetJWTPayload,
                      bool(std::map<std::string, std::string> *payload));
-  MOCK_CONST_METHOD0(IsMutualTlsEnabledConnection, bool());
+  MOCK_CONST_METHOD0(IsMutualTLS, bool());
 };
 
 // The mock object for HeaderUpdate interface.

--- a/control/src/http/mock_check_data.h
+++ b/control/src/http/mock_check_data.h
@@ -41,6 +41,7 @@ class MockCheckData : public CheckData {
                      bool(const std::string &name, std::string *value));
   MOCK_CONST_METHOD1(GetJWTPayload,
                      bool(std::map<std::string, std::string> *payload));
+  MOCK_CONST_METHOD0(IsMutualTlsEnabledConnection, bool());
 };
 
 // The mock object for HeaderUpdate interface.

--- a/control/src/http/mock_report_data.h
+++ b/control/src/http/mock_report_data.h
@@ -26,6 +26,7 @@ namespace http {
 // The mock object for ReportData interface.
 class MockReportData : public ReportData {
  public:
+  MOCK_CONST_METHOD2(GetDestinationIpPort, bool(std::string* ip, int* port));
   MOCK_CONST_METHOD0(GetResponseHeaders, std::map<std::string, std::string>());
   MOCK_CONST_METHOD1(GetReportInfo, void(ReportInfo* info));
 };

--- a/control/src/tcp/attributes_builder.cc
+++ b/control/src/tcp/attributes_builder.cc
@@ -36,6 +36,9 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData* check_data) {
   if (check_data->GetSourceUser(&source_user)) {
     builder.AddString(AttributeName::kSourceUser, source_user);
   }
+  builder.AddBool(AttributeName::kConnectionMtls,
+                  check_data->IsMutualTlsEnabledConnection());
+
   builder.AddTimestamp(AttributeName::kContextTime,
                        std::chrono::system_clock::now());
   builder.AddString(AttributeName::kContextProtocol, "tcp");

--- a/control/src/tcp/attributes_builder.cc
+++ b/control/src/tcp/attributes_builder.cc
@@ -36,8 +36,7 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData* check_data) {
   if (check_data->GetSourceUser(&source_user)) {
     builder.AddString(AttributeName::kSourceUser, source_user);
   }
-  builder.AddBool(AttributeName::kConnectionMtls,
-                  check_data->IsMutualTlsEnabledConnection());
+  builder.AddBool(AttributeName::kConnectionMtls, check_data->IsMutualTLS());
 
   builder.AddTimestamp(AttributeName::kContextTime,
                        std::chrono::system_clock::now());

--- a/control/src/tcp/attributes_builder_test.cc
+++ b/control/src/tcp/attributes_builder_test.cc
@@ -55,6 +55,12 @@ attributes {
   }
 }
 attributes {
+  key: "connection.mtls"
+  value {
+    bool_value: true
+  }
+}
+attributes {
   key: "source.port"
   value {
     int64_value: 8080
@@ -241,6 +247,8 @@ TEST(AttributesBuilderTest, TestCheckAttributes) {
         *port = 8080;
         return true;
       }));
+  EXPECT_CALL(mock_data, IsMutualTlsEnabledConnection())
+      .WillOnce(Invoke([]() -> bool { return true; }));
   EXPECT_CALL(mock_data, GetSourceUser(_))
       .WillOnce(Invoke([](std::string* user) -> bool {
         *user = "test_user";

--- a/control/src/tcp/attributes_builder_test.cc
+++ b/control/src/tcp/attributes_builder_test.cc
@@ -247,8 +247,9 @@ TEST(AttributesBuilderTest, TestCheckAttributes) {
         *port = 8080;
         return true;
       }));
-  EXPECT_CALL(mock_data, IsMutualTlsEnabledConnection())
-      .WillOnce(Invoke([]() -> bool { return true; }));
+  EXPECT_CALL(mock_data, IsMutualTLS()).WillOnce(Invoke([]() -> bool {
+    return true;
+  }));
   EXPECT_CALL(mock_data, GetSourceUser(_))
       .WillOnce(Invoke([](std::string* user) -> bool {
         *user = "test_user";

--- a/control/src/tcp/attributes_builder_test.cc
+++ b/control/src/tcp/attributes_builder_test.cc
@@ -247,9 +247,8 @@ TEST(AttributesBuilderTest, TestCheckAttributes) {
         *port = 8080;
         return true;
       }));
-  EXPECT_CALL(mock_data, IsMutualTLS()).WillOnce(Invoke([]() -> bool {
-    return true;
-  }));
+  EXPECT_CALL(mock_data, IsMutualTLS())
+      .WillOnce(Invoke([]() -> bool { return true; }));
   EXPECT_CALL(mock_data, GetSourceUser(_))
       .WillOnce(Invoke([](std::string* user) -> bool {
         *user = "test_user";

--- a/control/src/tcp/mock_check_data.h
+++ b/control/src/tcp/mock_check_data.h
@@ -28,6 +28,7 @@ class MockCheckData : public CheckData {
  public:
   MOCK_CONST_METHOD2(GetSourceIpPort, bool(std::string* ip, int* port));
   MOCK_CONST_METHOD1(GetSourceUser, bool(std::string* user));
+  MOCK_CONST_METHOD0(IsMutualTlsEnabledConnection, bool());
 };
 
 }  // namespace tcp

--- a/control/src/tcp/mock_check_data.h
+++ b/control/src/tcp/mock_check_data.h
@@ -28,7 +28,7 @@ class MockCheckData : public CheckData {
  public:
   MOCK_CONST_METHOD2(GetSourceIpPort, bool(std::string* ip, int* port));
   MOCK_CONST_METHOD1(GetSourceUser, bool(std::string* user));
-  MOCK_CONST_METHOD0(IsMutualTlsEnabledConnection, bool());
+  MOCK_CONST_METHOD0(IsMutualTLS, bool());
 };
 
 }  // namespace tcp


### PR DESCRIPTION
**What this PR does / why we need it**: Introduce new mixer attribute "connection.mtls" which indicates whether connection is mutual TLS enabled. Add virtual function bool IsMutualTlsEnabledConnection() into http/check_data.h and tcp/check_data.h, and call this function inside AttributesBuilder::ExtractCheckAttributes(). Add another virtual function bool GetDestinationIpPort(std::string* ip, int* port) to report destination IP and port from HTTP filter.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #426 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
